### PR TITLE
More style updates

### DIFF
--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -47,7 +47,7 @@ export type API = {
 
 type SchemaPropertyType = "string" | "integer" | "array" | "object";
 export type APISchema = {
-  components: {
+  components?: {
     schemas: {
       Author?: {
         properties: { [key: string]: SchemaPropertyType };
@@ -70,7 +70,7 @@ export type APISchema = {
   paths: {
     [key: string]: unknown;
   };
-  servers: {
+  servers?: {
     url: string;
   }[];
 };

--- a/projects/ui/src/Components/ApiDetails/ApiDetailsPage.tsx
+++ b/projects/ui/src/Components/ApiDetails/ApiDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
 import { APISchema } from "../../Apis/api-types";
 import { useGetApiDetails } from "../../Apis/hooks";
@@ -27,8 +28,8 @@ function HeaderSummary({ apiSchema }: { apiSchema: APISchema }) {
  * MAIN COMPONENT
  **/
 export function ApiDetailsPage() {
+  di(useGetApiDetails, useParams);
   const { apiId } = useParams();
-
   const { data: apiSchema } = useGetApiDetails(apiId);
 
   return (

--- a/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
+++ b/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@mantine/core";
 import { useState } from "react";
+import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
 import { useGetApiDetails } from "../../Apis/hooks";
 import { Loading } from "../Common/Loading";
@@ -10,8 +11,8 @@ import { SwaggerDisplay } from "./SwaggerDisplay";
  * MAIN COMPONENT
  **/
 export function ApiSchemaDisplay() {
+  di(useGetApiDetails, useParams);
   const { apiId } = useParams();
-
   const { isLoading, data: apiSchema } = useGetApiDetails(apiId);
   const [isSwagger, setIsSwagger] = useState(false);
 

--- a/projects/ui/src/Components/Common/Modal.tsx
+++ b/projects/ui/src/Components/Common/Modal.tsx
@@ -11,6 +11,7 @@ export function Modal({
   headContent: JSX.Element; // ususally just an icon
   title?: string;
   bodyContent?: JSX.Element;
+  /** The clasNames are applied to the .mantine-Modal-root, which is outside the modal and page overlay. */
   className?: string;
 }) {
   // The modal "mask" is overriden in "main.scss" rather than with

--- a/projects/ui/src/Components/Common/Modal.tsx
+++ b/projects/ui/src/Components/Common/Modal.tsx
@@ -5,17 +5,24 @@ export function Modal({
   headContent,
   title,
   bodyContent,
+  className,
 }: {
   onClose: () => any;
   headContent: JSX.Element; // ususally just an icon
   title?: string;
   bodyContent?: JSX.Element;
+  className?: string;
 }) {
   // The modal "mask" is overriden in "main.scss" rather than with
   //   the overlayProps so that we have easy access to our
   //   color constants.
   return (
-    <MantineModal opened={true} onClose={onClose} centered>
+    <MantineModal
+      opened={true}
+      onClose={onClose}
+      className={className}
+      centered
+    >
       <div className="modalBox">
         <div className="modalHeader">{headContent}</div>
         {!!title && <div className="modalTitle">{title}</div>}

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import { ReactComponent as Logo } from "../../Assets/logo.svg";
 import { ErrorBoundary } from "../Common/ErrorBoundary";
@@ -10,15 +10,9 @@ import { LoggedInUser } from "./LoggedInUser";
 export function Header() {
   const routerLocation = useLocation();
 
-  const [inAPIsArea, setInAPIsArea] = useState(
-    routerLocation.pathname.includes("/api") ||
-      routerLocation.pathname.includes("/api-details/")
-  );
-
-  useEffect(() => {
-    setInAPIsArea(
-      routerLocation.pathname.includes("/apis/") ||
-        routerLocation.pathname.includes("/api-details/")
+  const inAPIsArea = useMemo(() => {
+    return ["/apis", "/api-details/"].some((s) =>
+      routerLocation.pathname.includes(s)
     );
   }, [routerLocation.pathname]);
 

--- a/projects/ui/src/Components/Structure/LoggedInUser.tsx
+++ b/projects/ui/src/Components/Structure/LoggedInUser.tsx
@@ -1,7 +1,7 @@
 import { Popover } from "@mantine/core";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { di } from "react-magnetic-di";
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import { restpointPrefix, useGetCurrentUser } from "../../Apis/hooks";
 import { Icon } from "../../Assets/Icons";
 
@@ -11,6 +11,13 @@ import { Icon } from "../../Assets/Icons";
 export function LoggedInUser() {
   di(useGetCurrentUser);
   const { data: user } = useGetCurrentUser();
+
+  const routerLocation = useLocation();
+  const inUsagePlansArea = useMemo(
+    () => routerLocation.pathname.includes("/usage-plans"),
+    [routerLocation.pathname]
+  );
+
   const [opened, setOpened] = useState(false);
 
   // eslint-disable-next-line no-console
@@ -25,7 +32,7 @@ export function LoggedInUser() {
   ) : (
     <Popover position="bottom" opened={opened} onChange={setOpened}>
       <Popover.Target>
-        <div
+        <button
           className="userLoginArea loggedIn"
           onClick={() => setOpened(!opened)}
         >
@@ -35,11 +42,15 @@ export function LoggedInUser() {
               className={`dropdownArrow canRotate ${opened ? "rotate180" : ""}`}
             />
           </div>
-        </div>
+        </button>
       </Popover.Target>
-      <Popover.Dropdown>
-        <div className="userDropdown">
-          <NavLink to={"/usage-plans"} onClick={() => setOpened(!opened)}>
+      <Popover.Dropdown className="userDropdown">
+        <>
+          <NavLink
+            to={"/usage-plans"}
+            className={inUsagePlansArea ? "active" : ""}
+            onClick={() => setOpened(!opened)}
+          >
             API Keys
           </NavLink>
           <a
@@ -48,7 +59,7 @@ export function LoggedInUser() {
           >
             Logout
           </a>
-        </div>
+        </>
       </Popover.Dropdown>
     </Popover>
   );

--- a/projects/ui/src/Components/UsagePlans/ApiKeys/ApiKeyDetailsModal.tsx
+++ b/projects/ui/src/Components/UsagePlans/ApiKeys/ApiKeyDetailsModal.tsx
@@ -14,11 +14,12 @@ export function ApiKeyDetailsModal({
 }) {
   return (
     <Modal
+      className="keyDetailsModal"
       onClose={onClose}
       headContent={<Icon.CircledKey />}
       title={"Key Details"}
       bodyContent={
-        <div className="keyDetailsModal">
+        <div className="keyDetailsModalBody">
           <div className="planAccessCarveOut" aria-labelledby="planAccessLabel">
             <label className="title" id="planAccessLabel">
               Access to:
@@ -31,7 +32,7 @@ export function ApiKeyDetailsModal({
               aria-labelledby="customMetadataLabel"
             >
               <label className="title" id="customMetadataLabel">
-                Custom Metadata
+                Custom Meta Data
               </label>
               <div className="metadataList dataPairPillList">
                 {Object.entries(apiKey.metadata).map(([pairKey, pairValue]) => (

--- a/projects/ui/src/Components/UsagePlans/ApiKeys/ApiKeyDetailsModal.tsx
+++ b/projects/ui/src/Components/UsagePlans/ApiKeys/ApiKeyDetailsModal.tsx
@@ -14,7 +14,7 @@ export function ApiKeyDetailsModal({
 }) {
   return (
     <Modal
-      className="keyDetailsModal"
+      className="keyDetailsModalRoot"
       onClose={onClose}
       headContent={<Icon.CircledKey />}
       title={"Key Details"}

--- a/projects/ui/src/Components/UsagePlans/ApiKeys/ApiKeyDetailsModal.tsx
+++ b/projects/ui/src/Components/UsagePlans/ApiKeys/ApiKeyDetailsModal.tsx
@@ -20,6 +20,7 @@ export function ApiKeyDetailsModal({
       title={"Key Details"}
       bodyContent={
         <div className="keyDetailsModalBody">
+          <label className="keyName">{apiKey.name}</label>
           <div className="planAccessCarveOut" aria-labelledby="planAccessLabel">
             <label className="title" id="planAccessLabel">
               Access to:

--- a/projects/ui/src/Components/UsagePlans/ApiKeys/GenerateApiKeyModal.tsx
+++ b/projects/ui/src/Components/UsagePlans/ApiKeys/GenerateApiKeyModal.tsx
@@ -166,6 +166,7 @@ export function GenerateApiKeyModal({
 
   return (
     <Modal
+      className="generateKeyModal"
       onClose={() => {
         // If we have generated and not copied the API key,
         // prevent the user from closing the modal.
@@ -180,7 +181,7 @@ export function GenerateApiKeyModal({
       }
       title={generated ? "Key Generated Successfully!" : "Generate a New Key"}
       bodyContent={
-        <div className="generateKeyModal">
+        <div className="generateKeyModalBody">
           {!generated && (
             <>
               <div className="inputLine">
@@ -198,7 +199,11 @@ export function GenerateApiKeyModal({
                 <label className="title" id="planAccessLabel">
                   Access to:
                 </label>
-                <div className="planName">{usagePlanName}</div>
+                {/* 
+                // Can add usage plan description styles here.
+                <div className="planDescription"></div> 
+                */}
+                <div className="planName">{usagePlanName} Plan</div>
               </div>
               {/* 
               // TODO: Enable this when the backend supports custom metadata.

--- a/projects/ui/src/Components/UsagePlans/ApiKeys/GenerateApiKeyModal.tsx
+++ b/projects/ui/src/Components/UsagePlans/ApiKeys/GenerateApiKeyModal.tsx
@@ -166,7 +166,7 @@ export function GenerateApiKeyModal({
 
   return (
     <Modal
-      className="generateKeyModal"
+      className="generateKeyModalRoot"
       onClose={() => {
         // If we have generated and not copied the API key,
         // prevent the user from closing the modal.

--- a/projects/ui/src/Styles/Features/_redoc.scss
+++ b/projects/ui/src/Styles/Features/_redoc.scss
@@ -86,6 +86,8 @@
           padding: 0px;
           margin: 0px;
           background-color: constants.$marchGrey;
+          //
+          // These are the li elements (one for each search result row) in the search result list.
           li {
             background: white;
             flex-basis: 100%;
@@ -98,6 +100,7 @@
             }
           }
         }
+        // These are the styles for the "no results were found" empty state.
         > div[data-role="search:results"] {
           text-align: center;
           margin-top: 5px;
@@ -105,14 +108,18 @@
         }
       }
 
+      // These are the styles for the li elements in the sidebar sub-menus.
+      // (when a sidebar navigation accordion menu is expanded).
       li {
         border-top: 1px solid darken(constants.$marchGrey, 3);
       }
+      // These are the styles for the li elements in the sidebar top-level-menus.
       .scrollbar-container > ul > li {
         border-top: 1px solid darken(constants.$marchGrey, 5);
         &:last-of-type {
           border-bottom: 1px solid darken(constants.$marchGrey, 5);
         }
+        // This lightens the background color of expanded sub-menus.
         ul {
           background-color: lighten(constants.$marchGrey, 5);
         }
@@ -322,10 +329,13 @@
     }
   }
 
+  // These are the buttons with the method and path name on the right side.
+  // Clicking on them shows the full URL for each endpoint.
   button.sc-eGFuAX {
     margin-top: 10px;
     border-radius: 0px;
   }
+  // These are some general styles for interactive elements.
   a,
   button:not(:disabled),
   [role="tablist"] li {

--- a/projects/ui/src/Styles/Features/_redoc.scss
+++ b/projects/ui/src/Styles/Features/_redoc.scss
@@ -327,7 +327,7 @@
     border-radius: 0px;
   }
   a,
-  button,
+  button:not(:disabled),
   [role="tablist"] li {
     outline-offset: 2px;
     &:hover,

--- a/projects/ui/src/Styles/Features/_redoc.scss
+++ b/projects/ui/src/Styles/Features/_redoc.scss
@@ -40,12 +40,14 @@
       div[role="search"] {
         position: relative;
         margin-top: 10px;
+        padding: 0px;
 
         input {
           border-radius: constants.$smallBorderRadius;
           height: 34px;
           line-height: 34px;
           padding: 0 13px;
+          margin-bottom: 10px;
 
           font-size: 18px;
           font-weight: normal;
@@ -61,10 +63,11 @@
           display: none;
         }
         svg {
+          pointer-events: none;
           left: auto;
-          right: 25px;
-          top: 50%;
-          margin-top: -9px;
+          right: 28px;
+          top: 23px;
+          margin-top: -15px;
           width: 18px;
           height: 18px;
 
@@ -79,13 +82,58 @@
         }
         > div.scrollbar-container,
         div[data-role="search:results"] {
-          background: white;
+          min-height: 45px;
+          padding: 0px;
+          margin: 0px;
+          background-color: constants.$marchGrey;
+          li {
+            background: white;
+            flex-basis: 100%;
+            label {
+              padding: 15px 10px;
+            }
+            border: 1px solid constants.$marchGrey;
+            &:not(:last-of-type) {
+              border-bottom: none;
+            }
+          }
+        }
+        > div[data-role="search:results"] {
+          text-align: center;
+          margin-top: 5px;
+          margin-bottom: -10px;
+        }
+      }
+
+      li {
+        border-top: 1px solid darken(constants.$marchGrey, 3);
+      }
+      .scrollbar-container > ul > li {
+        border-top: 1px solid darken(constants.$marchGrey, 5);
+        &:last-of-type {
+          border-bottom: 1px solid darken(constants.$marchGrey, 5);
+        }
+        ul {
+          background-color: lighten(constants.$marchGrey, 5);
         }
       }
 
       // LABELS, typically of METHOD NAMES
       li > label {
-        background: transparent;
+        // When this is the active list item.
+        border-left: 4px solid transparent;
+        &.active {
+          border-left: 4px solid constants.$primaryColor;
+        }
+
+        // Keep background-color interaction.
+        background-color: transparent;
+        &:hover {
+          background-color: darken(constants.$marchGrey, 5);
+        }
+        &:active {
+          background-color: darken(constants.$marchGrey, 10);
+        }
 
         .operation-type {
           border-radius: constants.$smallBorderRadius;
@@ -271,6 +319,24 @@
 
     .fburAk {
       display: none;
+    }
+  }
+
+  button.sc-eGFuAX {
+    margin-top: 10px;
+    border-radius: 0px;
+  }
+  a,
+  button,
+  [role="tablist"] li {
+    outline-offset: 2px;
+    &:hover,
+    &:focus-visible {
+      outline: 1px solid constants.$primaryColor;
+    }
+    &:active {
+      outline: 2px solid constants.$primaryColor;
+      box-shadow: 0 0 5px constants.$primaryColor;
     }
   }
 }

--- a/projects/ui/src/Styles/Features/_swaggerui.scss
+++ b/projects/ui/src/Styles/Features/_swaggerui.scss
@@ -183,8 +183,8 @@ div[id^="display-swagger"] {
     div.copy-to-clipboard,
     .opblock-tag-section h3.opblock-tag,
     a,
-    button,
-    select {
+    button:not(:disabled),
+    select:not(:disabled) {
       outline-offset: 2px;
       &:hover,
       &:focus,

--- a/projects/ui/src/Styles/Features/_swaggerui.scss
+++ b/projects/ui/src/Styles/Features/_swaggerui.scss
@@ -169,5 +169,59 @@ div[id^="display-swagger"] {
         }
       }
     }
+
+    //
+    // Fixes some interaction issues with buttons in the main opblock sections.
+    // And makes it clearer when something is a button.
+    //
+    .opblock-summary {
+      padding: 0px;
+      > button {
+        padding: 5px;
+      }
+    }
+    div.copy-to-clipboard,
+    .opblock-tag-section h3.opblock-tag,
+    a,
+    button,
+    select {
+      outline-offset: 2px;
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        outline: 1px solid constants.$primaryColor;
+      }
+      &:active {
+        outline: 2px solid constants.$primaryColor;
+        box-shadow: 0 0 5px constants.$primaryColor;
+      }
+    }
+  }
+
+  //
+  // Fixes some of the layout in the Models section.
+  // width: 100% makes the expand buttons easier to find.
+  //
+  section.models {
+    position: relative;
+    .model-container > .model-box {
+      padding: 5px;
+    }
+    .model-box {
+      > button > .model-toggle.collapsed {
+        position: absolute;
+        top: 30px;
+        right: 15px;
+        margin-top: -10px;
+      }
+      width: 100%;
+      button.model-box-control {
+        width: 100%;
+      }
+      .model-toggle {
+        float: right;
+        margin-top: -2px;
+      }
+    }
   }
 }

--- a/projects/ui/src/Styles/Modals/_key-details.scss
+++ b/projects/ui/src/Styles/Modals/_key-details.scss
@@ -1,8 +1,11 @@
 @use "../constants";
 @use "../Features/apis-list";
 
-.generateKeyModal,
-.keyDetailsModal {
+//
+// The root classes are on the .mantine-Modal-root, which is
+// outside the modal and page overlay
+.generateKeyModalRoot,
+.keyDetailsModalRoot {
   .mantine-Modal-body {
     padding: 0px;
     .modalBox {

--- a/projects/ui/src/Styles/Modals/_key-details.scss
+++ b/projects/ui/src/Styles/Modals/_key-details.scss
@@ -3,108 +3,145 @@
 
 .generateKeyModal,
 .keyDetailsModal {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-
-  .inputLine,
-  .keyIdLine {
-    width: 100%;
-    margin-bottom: 15px;
-  }
-
-  .inputLine {
-    padding: 0 40px;
-    input {
-      font-size: 16px;
+  .mantine-Modal-body {
+    padding: 0px;
+    .modalBox {
+      max-width: 440px;
     }
   }
-
-  .keyIdLine {
-    font-size: 14px;
-    line-height: 28px;
+  .generateKeyModalBody,
+  .keyDetailsModalBody {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
-    button {
-      display: inline-block;
-      .keyId {
-        margin-right: 10px;
-        font-weight: normal;
-        color: constants.$internalLinkColor;
+    width: 100%;
+
+    .inputLine,
+    .keyIdLine {
+      width: 100%;
+      margin-bottom: 15px;
+    }
+
+    .inputLine {
+      padding: 0 40px;
+      margin-bottom: 20px;
+      input {
+        font-size: 16px;
       }
     }
-  }
 
-  .planAccessCarveOut {
-    width: auto;
-    padding: 10px 40px;
-    margin-bottom: 15px;
-    border-radius: 2px;
-    background: constants.$puddleBlue;
-    text-align: center;
-
-    .title {
-      margin-right: 5px;
-    }
-    .title,
-    .planName {
-      font-size: 22px;
+    .keyIdLine {
+      font-size: 14px;
       line-height: 28px;
-      color: constants.$defaultColoredText;
-      display: inline-block;
-      max-width: 100%;
-      word-break: break-word;
-    }
-  }
-
-  .pairHolder {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    color: constants.$juneGrey;
-    margin-bottom: 15px;
-
-    margin-top: 5px;
-    .textHolder {
-      flex-grow: 1;
-      input {
-        border-radius: constants.$smallBorderRadius;
-
-        border: 1px solid constants.$mayGrey;
-        outline: none;
-        box-shadow: none;
-
-        height: 25px;
-        line-height: 25px;
-        padding: 0 6px;
-
-        &::placeholder {
-          @extend .filterPlaceholderTexts;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      button {
+        display: inline-block;
+        .keyId {
+          margin-right: 10px;
+          font-weight: normal;
+          color: constants.$internalLinkColor;
         }
       }
     }
-  }
 
-  .customMetadata {
-    margin-bottom: 15px;
-    text-align: center;
-  }
+    .planAccessCarveOut {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      padding: 10px 40px;
+      margin-top: 5px;
+      margin-bottom: 25px;
+      background: constants.$puddleBlue;
+      text-align: center;
 
-  .addButtonHolder {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 34px;
-    width: 34px;
+      .title,
+      .planName .title {
+        display: inline-block;
+        max-width: 100%;
+        word-break: break-word;
+      }
+      .title {
+        margin-right: 5px;
+        font-size: 26px;
+        padding: 8px 0;
+        color: constants.$defaultColoredText;
+      }
+      .planName {
+        color: constants.$juneGrey;
+        font-size: 18px;
+      }
+      .planDescription {
+        font-weight: 600;
+        color: constants.$defaultColoredText;
+        padding-top: 5px;
+        font-size: 18px;
+      }
+    }
 
-    svg {
-      height: 21px;
-      width: 21px;
+    .pairHolder {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      color: constants.$juneGrey;
+      margin-bottom: 15px;
 
-      * {
-        fill: constants.$juneGrey;
+      margin-top: 5px;
+      .textHolder {
+        flex-grow: 1;
+        input {
+          border-radius: constants.$smallBorderRadius;
+
+          border: 1px solid constants.$mayGrey;
+          outline: none;
+          box-shadow: none;
+
+          height: 25px;
+          line-height: 25px;
+          padding: 0 6px;
+
+          &::placeholder {
+            @extend .filterPlaceholderTexts;
+          }
+        }
+      }
+    }
+
+    .customMetadata {
+      > label.title {
+        font-size: 26px;
+        // Add these subtitle styles if adding
+        // the "Meta Data (optional)" subtitle text.
+        // display: flex;
+        // gap: 10px;
+        // > span.subtitle {
+        //   font-size: 18px;
+        //   color: constants.$juneGrey;
+        // }
+      }
+      margin-bottom: 15px;
+      text-align: center;
+      .metadataList {
+        margin-top: 15px;
+        justify-content: center;
+      }
+    }
+
+    .addButtonHolder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 34px;
+      width: 34px;
+
+      svg {
+        height: 21px;
+        width: 21px;
+
+        * {
+          fill: constants.$juneGrey;
+        }
       }
     }
   }

--- a/projects/ui/src/Styles/Modals/_key-details.scss
+++ b/projects/ui/src/Styles/Modals/_key-details.scss
@@ -16,6 +16,14 @@
     align-items: center;
     width: 100%;
 
+    .keyName {
+      margin-bottom: 15px;
+      color: constants.$juneGrey;
+      padding: 0px 20px;
+      max-width: 100%;
+      word-break: break-all;
+    }
+
     .inputLine,
     .keyIdLine {
       width: 100%;

--- a/projects/ui/src/Styles/Modals/_key-details.scss
+++ b/projects/ui/src/Styles/Modals/_key-details.scss
@@ -117,6 +117,7 @@
     }
 
     .customMetadata {
+      padding: 0 20px;
       > label.title {
         font-size: 26px;
         // Add these subtitle styles if adding

--- a/projects/ui/src/Styles/Modals/_modal.scss
+++ b/projects/ui/src/Styles/Modals/_modal.scss
@@ -1,9 +1,14 @@
 @use "../constants";
 
+.mantine-Paper-root.mantine-Modal-content {
+  border-radius: 15px;
+}
+
 // Overrides the Mantine component library's close button styles.
 .mantine-Modal-header .mantine-Modal-close {
   width: 1.75rem;
   height: 1.75rem;
+  margin-right: 5px;
   svg {
     width: 24px;
     height: 24px;
@@ -17,7 +22,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: 30px;
+  padding-bottom: 35px;
   max-width: 425px;
 
   .modalHeader {

--- a/projects/ui/src/Styles/_breadcrumbs.scss
+++ b/projects/ui/src/Styles/_breadcrumbs.scss
@@ -3,8 +3,9 @@
 
 .breadcrumbList {
   @include mixins.contentWidth();
-  padding-top: 15px;
-  min-height: 41px;
+  padding-top: 20px;
+  padding-bottom: 5px;
+  min-height: 51px;
 
   display: flex;
   align-items: center;

--- a/projects/ui/src/Styles/_button.scss
+++ b/projects/ui/src/Styles/_button.scss
@@ -128,7 +128,7 @@ button {
   &.disabled,
   &.disabled:hover,
   &.disabled:active {
-    cursor: default;
+    cursor: not-allowed;
     background-color: constants.$juneGrey;
   }
 }

--- a/projects/ui/src/Styles/_topnav.scss
+++ b/projects/ui/src/Styles/_topnav.scss
@@ -138,7 +138,8 @@
   }
 }
 
-// Interaction
+// These are the hover/active styles for the links in the main top bar,
+// and links in the logged in user dropdown area.
 .navContent .userLoginArea.loggedIn,
 .navContent .logoContainer,
 .navContent .siteNavigating a.navLink,
@@ -156,6 +157,9 @@
     border-color: constants.$puddleBlue;
   }
 
+  // .active means that this is the page that the user is on.
+  // This overrides the font color and border color so that it doesn't
+  // get the same hover/active states.
   &.active,
   &.active:hover,
   &.active:active {

--- a/projects/ui/src/Styles/_topnav.scss
+++ b/projects/ui/src/Styles/_topnav.scss
@@ -75,7 +75,6 @@
     .userHolder {
       display: flex;
       align-items: center;
-      color: constants.$defaultColoredText;
 
       svg.userCircle {
         width: 40px;
@@ -97,22 +96,6 @@
       }
     }
   }
-
-  .userLoginArea.loggedIn,
-  .logoContainer,
-  .siteNavigating a.navLink {
-    cursor: pointer;
-    &:hover {
-      color: darken(constants.$internalLinkColor, 10);
-      background-color: lighten(constants.$puddleBlue, 9);
-      border-bottom-color: constants.$puddleBlue;
-    }
-    &:active {
-      color: darken(constants.$internalLinkColor, 10);
-      background-color: lighten(constants.$puddleBlue, 7);
-      border-bottom-color: constants.$puddleBlue;
-    }
-  }
 }
 
 .widerContent .navContent {
@@ -120,27 +103,30 @@
 }
 
 .userDropdown {
+  border: none;
+  box-shadow: constants.$marchGrey 0px 2px 3px 1px;
+  padding: 0px;
+  margin-top: -8px;
   white-space: nowrap;
   a,
   div {
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 0 18px;
+    padding: 5px 50px;
     line-height: 35px;
     cursor: pointer;
-    border-left: 6px solid transparent;
+    border-left: 4px solid transparent;
     border-bottom: 0px solid transparent !important;
-
-    &:hover {
-      border-left-color: constants.$internalLinkColor;
-    }
+    color: constants.$defaultColoredText;
 
     &:first-child {
       border-top-left-radius: 2px;
+      border-top-right-radius: 2px;
     }
     &:last-child {
       border-bottom-left-radius: 2px;
+      border-bottom-right-radius: 2px;
     }
   }
 
@@ -149,5 +135,31 @@
     color: constants.$juneGrey;
     border-left-color: constants.$juneGrey;
     cursor: default;
+  }
+}
+
+// Interaction
+.navContent .userLoginArea.loggedIn,
+.navContent .logoContainer,
+.navContent .siteNavigating a.navLink,
+.navContent .userLoginArea .userHolder,
+.userDropdown a {
+  cursor: pointer;
+  &:hover {
+    color: darken(constants.$internalLinkColor, 10);
+    background-color: lighten(constants.$puddleBlue, 9);
+    border-color: constants.$puddleBlue;
+  }
+  &:active {
+    color: darken(constants.$internalLinkColor, 10);
+    background-color: lighten(constants.$puddleBlue, 7);
+    border-color: constants.$puddleBlue;
+  }
+
+  &.active,
+  &.active:hover,
+  &.active:active {
+    color: constants.$internalLinkColor;
+    border-color: constants.$internalLinkColor;
   }
 }

--- a/projects/ui/src/stories/api-details/ApiDetailsPage.stories.tsx
+++ b/projects/ui/src/stories/api-details/ApiDetailsPage.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DiProvider, injectable } from "react-magnetic-di";
+import { MemoryRouter, useParams } from "react-router-dom";
+import { useGetApiDetails } from "../../Apis/hooks";
+import { ApiDetailsPage } from "../../Components/ApiDetails/ApiDetailsPage";
+import { appContentDecorator } from "../decorators/decorators";
+import exampleOpenApiSchema from "./exampleOpenApiSchema";
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+const meta = {
+  title: "API Details / API Details Page",
+  component: ApiDetailsPage,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ApiDetailsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+//
+// Variant: with example schema
+//
+// This uses an example schema from the OpenApi-Specification repository:
+// https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v2.0/json/uber.json
+//
+export const Default: Story = {
+  decorators: [
+    appContentDecorator,
+    (Story) => {
+      const useGetApiDetailsDi = injectable(useGetApiDetails, () => ({
+        isLoading: false,
+        data: exampleOpenApiSchema,
+      }));
+      const useParamsDi = injectable(useParams, () => ({
+        apiId: "swagger-petstore",
+      }));
+      return (
+        <MemoryRouter>
+          <DiProvider use={[useGetApiDetailsDi, useParamsDi]}>
+            <Story />
+          </DiProvider>
+        </MemoryRouter>
+      );
+    },
+  ],
+};

--- a/projects/ui/src/stories/api-details/exampleOpenApiSchema.ts
+++ b/projects/ui/src/stories/api-details/exampleOpenApiSchema.ts
@@ -1,0 +1,372 @@
+import { APISchema } from "../../Apis/api-types";
+
+export default {
+  swagger: "2.0",
+  info: {
+    title: "Uber API",
+    description: "Move your app forward with the Uber API",
+    version: "1.0.0",
+  },
+  host: "api.uber.com",
+  schemes: ["https"],
+  basePath: "/v1",
+  produces: ["application/json"],
+  paths: {
+    "/products": {
+      get: {
+        summary: "Product Types",
+        description:
+          "The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.",
+        parameters: [
+          {
+            name: "latitude",
+            in: "query",
+            description: "Latitude component of location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+          {
+            name: "longitude",
+            in: "query",
+            description: "Longitude component of location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+        ],
+        tags: ["Products"],
+        responses: {
+          "200": {
+            description: "An array of products",
+            schema: {
+              type: "array",
+              items: {
+                $ref: "#/definitions/Product",
+              },
+            },
+          },
+          default: {
+            description: "Unexpected error",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+          },
+        },
+      },
+    },
+    "/estimates/price": {
+      get: {
+        summary: "Price Estimates",
+        description:
+          "The Price Estimates endpoint returns an estimated price range for each product offered at a given location. The price estimate is provided as a formatted string with the full price range and the localized currency symbol.<br><br>The response also includes low and high estimates, and the [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code for situations requiring currency conversion. When surge is active for a particular product, its surge_multiplier will be greater than 1, but the price estimate already factors in this multiplier.",
+        parameters: [
+          {
+            name: "start_latitude",
+            in: "query",
+            description: "Latitude component of start location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+          {
+            name: "start_longitude",
+            in: "query",
+            description: "Longitude component of start location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+          {
+            name: "end_latitude",
+            in: "query",
+            description: "Latitude component of end location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+          {
+            name: "end_longitude",
+            in: "query",
+            description: "Longitude component of end location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+        ],
+        tags: ["Estimates"],
+        responses: {
+          "200": {
+            description: "An array of price estimates by product",
+            schema: {
+              type: "array",
+              items: {
+                $ref: "#/definitions/PriceEstimate",
+              },
+            },
+          },
+          default: {
+            description: "Unexpected error",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+          },
+        },
+      },
+    },
+    "/estimates/time": {
+      get: {
+        summary: "Time Estimates",
+        description:
+          "The Time Estimates endpoint returns ETAs for all products offered at a given location, with the responses expressed as integers in seconds. We recommend that this endpoint be called every minute to provide the most accurate, up-to-date ETAs.",
+        parameters: [
+          {
+            name: "start_latitude",
+            in: "query",
+            description: "Latitude component of start location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+          {
+            name: "start_longitude",
+            in: "query",
+            description: "Longitude component of start location.",
+            required: true,
+            type: "number",
+            format: "double",
+          },
+          {
+            name: "customer_uuid",
+            in: "query",
+            type: "string",
+            format: "uuid",
+            description:
+              "Unique customer identifier to be used for experience customization.",
+          },
+          {
+            name: "product_id",
+            in: "query",
+            type: "string",
+            description:
+              "Unique identifier representing a specific product for a given latitude & longitude.",
+          },
+        ],
+        tags: ["Estimates"],
+        responses: {
+          "200": {
+            description: "An array of products",
+            schema: {
+              type: "array",
+              items: {
+                $ref: "#/definitions/Product",
+              },
+            },
+          },
+          default: {
+            description: "Unexpected error",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+          },
+        },
+      },
+    },
+    "/me": {
+      get: {
+        summary: "User Profile",
+        description:
+          "The User Profile endpoint returns information about the Uber user that has authorized with the application.",
+        tags: ["User"],
+        responses: {
+          "200": {
+            description: "Profile information for a user",
+            schema: {
+              $ref: "#/definitions/Profile",
+            },
+          },
+          default: {
+            description: "Unexpected error",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+          },
+        },
+      },
+    },
+    "/history": {
+      get: {
+        summary: "User Activity",
+        description:
+          "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will include pickup locations and times, dropoff locations and times, the distance of past requests, and information about which products were requested.<br><br>The history array in the response will have a maximum length based on the limit parameter. The response value count may exceed limit, therefore subsequent API requests may be necessary.",
+        parameters: [
+          {
+            name: "offset",
+            in: "query",
+            type: "integer",
+            format: "int32",
+            description:
+              "Offset the list of returned results by this amount. Default is zero.",
+          },
+          {
+            name: "limit",
+            in: "query",
+            type: "integer",
+            format: "int32",
+            description:
+              "Number of items to retrieve. Default is 5, maximum is 100.",
+          },
+        ],
+        tags: ["User"],
+        responses: {
+          "200": {
+            description: "History information for the given user",
+            schema: {
+              $ref: "#/definitions/Activities",
+            },
+          },
+          default: {
+            description: "Unexpected error",
+            schema: {
+              $ref: "#/definitions/Error",
+            },
+          },
+        },
+      },
+    },
+  },
+  definitions: {
+    Product: {
+      properties: {
+        product_id: {
+          type: "string",
+          description:
+            "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
+        },
+        description: {
+          type: "string",
+          description: "Description of product.",
+        },
+        display_name: {
+          type: "string",
+          description: "Display name of product.",
+        },
+        capacity: {
+          type: "string",
+          description: "Capacity of product. For example, 4 people.",
+        },
+        image: {
+          type: "string",
+          description: "Image URL representing the product.",
+        },
+      },
+    },
+    PriceEstimate: {
+      properties: {
+        product_id: {
+          type: "string",
+          description:
+            "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles",
+        },
+        currency_code: {
+          type: "string",
+          description:
+            "[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.",
+        },
+        display_name: {
+          type: "string",
+          description: "Display name of product.",
+        },
+        estimate: {
+          type: "string",
+          description:
+            'Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.',
+        },
+        low_estimate: {
+          type: "number",
+          description: "Lower bound of the estimated price.",
+        },
+        high_estimate: {
+          type: "number",
+          description: "Upper bound of the estimated price.",
+        },
+        surge_multiplier: {
+          type: "number",
+          description:
+            "Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.",
+        },
+      },
+    },
+    Profile: {
+      properties: {
+        first_name: {
+          type: "string",
+          description: "First name of the Uber user.",
+        },
+        last_name: {
+          type: "string",
+          description: "Last name of the Uber user.",
+        },
+        email: {
+          type: "string",
+          description: "Email address of the Uber user",
+        },
+        picture: {
+          type: "string",
+          description: "Image URL of the Uber user.",
+        },
+        promo_code: {
+          type: "string",
+          description: "Promo code of the Uber user.",
+        },
+      },
+    },
+    Activity: {
+      properties: {
+        uuid: {
+          type: "string",
+          description: "Unique identifier for the activity",
+        },
+      },
+    },
+    Activities: {
+      properties: {
+        offset: {
+          type: "integer",
+          format: "int32",
+          description: "Position in pagination.",
+        },
+        limit: {
+          type: "integer",
+          format: "int32",
+          description: "Number of items to retrieve (100 max).",
+        },
+        count: {
+          type: "integer",
+          format: "int32",
+          description: "Total number of items available.",
+        },
+        history: {
+          type: "array",
+          items: {
+            $ref: "#/definitions/Activity",
+          },
+        },
+      },
+    },
+    Error: {
+      properties: {
+        code: {
+          type: "integer",
+          format: "int32",
+        },
+        message: {
+          type: "string",
+        },
+        fields: {
+          type: "string",
+        },
+      },
+    },
+  },
+} as APISchema;

--- a/projects/ui/src/stories/api-keys/ApiKeyDetailsModal.stories.tsx
+++ b/projects/ui/src/stories/api-keys/ApiKeyDetailsModal.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ApiKeyDetailsModal } from "../../Components/UsagePlans/ApiKeys/ApiKeyDetailsModal";
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+const meta = {
+  title: "API Keys / API Key Details Modal",
+  component: ApiKeyDetailsModal,
+} satisfies Meta<typeof ApiKeyDetailsModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+export const Default: Story = {
+  args: {
+    usagePlanName: "some-usage-plan",
+    apiKey: {
+      apiKey: undefined,
+      id: "example-key-id",
+      name: "Example API Key Name",
+      metadata: {
+        "some-key": "some-value",
+      },
+    },
+  },
+};

--- a/projects/ui/src/stories/api-keys/UsagePlansPage.stories.tsx
+++ b/projects/ui/src/stories/api-keys/UsagePlansPage.stories.tsx
@@ -8,12 +8,14 @@ import {
   useListUsagePlans,
 } from "../../Apis/hooks";
 import { UsagePlansPage } from "../../Components/UsagePlans/UsagePlansPage";
+import { appContentDecorator } from "../decorators/decorators";
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 // More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
 const meta = {
   title: "API Keys / Usage Plans Page",
   component: UsagePlansPage,
+  parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof UsagePlansPage>;
 
 export default meta;
@@ -83,6 +85,7 @@ const mockApiKeys: DeepPartialObject<{
 
 export const Default: Story = {
   decorators: [
+    appContentDecorator,
     (Story) => {
       //
       // 2. Create the injectable hooks using react-magnetic-di.

--- a/projects/ui/src/stories/apis/ApisPage.stories.tsx
+++ b/projects/ui/src/stories/apis/ApisPage.stories.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import { API } from "../../Apis/api-types";
 import { useListApis } from "../../Apis/hooks";
 import { ApisPage } from "../../Components/ApisList/ApisPage";
+import { appContentDecorator } from "../decorators/decorators";
 import { arrGen } from "../generators";
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
@@ -12,6 +13,7 @@ import { arrGen } from "../generators";
 const meta = {
   title: "APIs / APIs Page",
   component: ApisPage,
+  parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof ApisPage>;
 
 export default meta;
@@ -64,6 +66,7 @@ const mockApisList: DeepPartialObject<API>[] = [
 ];
 export const Default: Story = {
   decorators: [
+    appContentDecorator,
     (Story) => {
       const useListApisDi = injectable(useListApis, () => ({
         isLoading: false,

--- a/projects/ui/src/stories/auth/LoggedOut.stories.tsx
+++ b/projects/ui/src/stories/auth/LoggedOut.stories.tsx
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 import LoggedOut from "../../Components/Common/LoggedOut";
+import { appContentDecorator } from "../decorators/decorators";
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta = {
   title: "Auth / Logout Screen",
   component: LoggedOut,
+  parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof LoggedOut>;
 
 export default meta;
@@ -14,6 +16,7 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
 export const Default: Story = {
   decorators: [
+    appContentDecorator,
     (Story) => (
       <MemoryRouter>
         <Story />

--- a/projects/ui/src/stories/auth/LoginScreen.stories.tsx
+++ b/projects/ui/src/stories/auth/LoginScreen.stories.tsx
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { MemoryRouter } from "react-router-dom";
 import LoginRedirect from "../../Components/Common/LoginRedirect";
+import { appContentDecorator } from "../decorators/decorators";
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
 const meta = {
   title: "Auth / Login Screen",
   component: LoginRedirect,
+  parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof LoginRedirect>;
 
 export default meta;
@@ -14,6 +16,7 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
 export const Default: Story = {
   decorators: [
+    appContentDecorator,
     (Story) => (
       <MemoryRouter>
         <Story />

--- a/projects/ui/src/stories/decorators/decorators.tsx
+++ b/projects/ui/src/stories/decorators/decorators.tsx
@@ -1,0 +1,9 @@
+import { Decorator } from "@storybook/react";
+
+export const appContentDecorator: Decorator = (Story) => {
+  return (
+    <div className="AppContent" data-theme={"light"}>
+      <Story />
+    </div>
+  );
+};

--- a/projects/ui/src/stories/decorators/decorators.tsx
+++ b/projects/ui/src/stories/decorators/decorators.tsx
@@ -2,7 +2,7 @@ import { Decorator } from "@storybook/react";
 
 export const appContentDecorator: Decorator = (Story) => {
   return (
-    <div className="AppContent" data-theme={"light"}>
+    <div className="AppContainer" data-theme={"light"}>
       <Story />
     </div>
   );


### PR DESCRIPTION
This PR wraps up the rest of the style updates identified [in this issue](https://github.com/solo-io/gloo-mesh-enterprise/issues/8750). Some of the updates include:
- hover/active states for navbar links when logged in
- redoc + swagger style override changes
- More stories, including an API details page story with an example OpenAPI schema. Also using the [layout parameter](https://storybook.js.org/docs/react/configure/story-layout), and a story decorator for pages to better match the style of the real app.
- Updated styles for the usage plan banner and metadata sections of the API key details and generate API key modals.

<img width="477" alt="Screenshot 2023-04-19 at 4 09 15 PM" src="https://user-images.githubusercontent.com/4720646/233188455-5ea628a2-62c6-4562-8d0a-9ae1d0469489.png">


<img width="477" alt="Screenshot 2023-04-19 at 4 08 58 PM" src="https://user-images.githubusercontent.com/4720646/233188400-2f0130d5-7907-4801-960b-cbae6055b600.png">

Logged in navbar updates to match the rest of the navbar hover/active states.

<img width="401" alt="Screenshot 2023-04-19 at 4 17 27 PM" src="https://user-images.githubusercontent.com/4720646/233190109-eecf796e-e430-4ddd-9ad6-86af40e70f38.png">

Redoc sidebar style updates:

<img width="402" alt="Screenshot 2023-04-19 at 4 19 00 PM" src="https://user-images.githubusercontent.com/4720646/233190433-1e324ce4-83d0-4076-998e-b4275a91528b.png">
