### PR TITLE
Backstage API exporter demo behind feature flag, and small style fix.

### DIFF
--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -33,7 +33,8 @@
     "storybook": "^7.0.2",
     "styled-components": "^5.3.6",
     "swagger-ui": "^4.18.2",
-    "swr": "^2.1.3"
+    "swr": "^2.1.3",
+    "yaml": "^2.2.2"
   },
   "devDependencies": {
     "@emotion/eslint-plugin": "^11.10.0",

--- a/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
+++ b/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
@@ -1,19 +1,64 @@
 import { Button } from "@mantine/core";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
-import { useGetApiDetails } from "../../Apis/hooks";
+import YAML from "yaml";
+import { useGetApiDetails, useListApis } from "../../Apis/hooks";
 import { Loading } from "../Common/Loading";
 import { RedocDisplay } from "./RedocDisplay";
 import { SwaggerDisplay } from "./SwaggerDisplay";
+
+// This is a flag to enable the backstage yaml download button.
+const BACKSTAGE_YAML_DEMO_ENABLED = false;
+
+function keyValue(theKey: string, ...theValues: (string | undefined)[]) {
+  let truthyValue = "";
+  for (let i = 0; i < theValues.length; i++) {
+    const cur = theValues[i];
+    if (cur !== undefined) {
+      truthyValue = cur;
+      break;
+    }
+  }
+  if (!truthyValue) return "";
+  else return theKey + ": " + truthyValue;
+}
 
 /**
  * MAIN COMPONENT
  **/
 export function ApiSchemaDisplay() {
-  di(useGetApiDetails, useParams);
+  di(useGetApiDetails, useParams, useListApis);
   const { apiId } = useParams();
-  const { isLoading, data: apiSchema } = useGetApiDetails(apiId);
+  const { isLoading: isLoadingApiDetails, data: apiSchema } =
+    useGetApiDetails(apiId);
+  const { isLoading: isLoadingApisList, data: apisList } = useListApis();
+
+  const backstageYaml = useMemo(() => {
+    if (!BACKSTAGE_YAML_DEMO_ENABLED) return undefined;
+    const apiSummary = apisList?.find((a) => a.apiId === apiId);
+    if (!apiSummary || !apiSchema) return undefined;
+    const meta = apiSummary.customMetadata;
+    const apiSchemaYamlStr = YAML.stringify(apiSchema);
+    return `apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: ${apiSummary.title.replaceAll(" ", "-")}
+  description: ${apiSummary.description}
+spec:
+  type: openapi
+  ${keyValue("owner", meta?.owner, apiSummary.contact)}
+  ${keyValue("lifecycle", meta?.lifecycle, "production")}
+  definition: |-
+    ${
+      // Add in the indents.
+      apiSchemaYamlStr.replaceAll("\n", "\n    ")
+    }
+`;
+  }, [apisList, apiSchema]);
+
+  const isLoading = isLoadingApiDetails || isLoadingApisList;
+
   const [isSwagger, setIsSwagger] = useState(false);
 
   if (isLoading) {
@@ -30,6 +75,19 @@ export function ApiSchemaDisplay() {
         >
           {isSwagger ? "Redoc" : "Swagger"} View
         </Button>
+        {backstageYaml !== undefined && (
+          <a
+            target="_blank"
+            download={`catalog-info-${apiId}.yaml`}
+            href={`data:text/plain;charset=utf-8,${encodeURIComponent(
+              backstageYaml
+            )}`}
+          >
+            <Button variant="subtle" size="xs">
+              Download Backstage YAML
+            </Button>
+          </a>
+        )}
       </div>
       <main className="page-container-wrapper">
         {!isSwagger ? (

--- a/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
+++ b/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
@@ -4,6 +4,7 @@ import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
 import YAML from "yaml";
 import { useGetApiDetails, useListApis } from "../../Apis/hooks";
+import { downloadTextFile } from "../../Utility/utility";
 import { Loading } from "../Common/Loading";
 import { RedocDisplay } from "./RedocDisplay";
 import { SwaggerDisplay } from "./SwaggerDisplay";
@@ -76,17 +77,15 @@ spec:
           {isSwagger ? "Redoc" : "Swagger"} View
         </Button>
         {backstageYaml !== undefined && (
-          <a
-            target="_blank"
-            download={`catalog-info-${apiId}.yaml`}
-            href={`data:text/plain;charset=utf-8,${encodeURIComponent(
-              backstageYaml
-            )}`}
+          <Button
+            variant="subtle"
+            onClick={() =>
+              downloadTextFile(`catalog-info-${apiId}.yaml`, backstageYaml)
+            }
+            size="xs"
           >
-            <Button variant="subtle" size="xs">
-              Download Backstage YAML
-            </Button>
-          </a>
+            Download Backstage YAML
+          </Button>
         )}
       </div>
       <main className="page-container-wrapper">

--- a/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
+++ b/projects/ui/src/Components/ApiDetails/ApiSchemaDisplay.tsx
@@ -4,7 +4,7 @@ import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
 import YAML from "yaml";
 import { useGetApiDetails, useListApis } from "../../Apis/hooks";
-import { downloadTextFile } from "../../Utility/utility";
+import { downloadFile } from "../../Utility/utility";
 import { Loading } from "../Common/Loading";
 import { RedocDisplay } from "./RedocDisplay";
 import { SwaggerDisplay } from "./SwaggerDisplay";
@@ -80,7 +80,7 @@ spec:
           <Button
             variant="subtle"
             onClick={() =>
-              downloadTextFile(`catalog-info-${apiId}.yaml`, backstageYaml)
+              downloadFile(`catalog-info-${apiId}.yaml`, backstageYaml)
             }
             size="xs"
           >

--- a/projects/ui/src/Components/UsagePlans/UsagePlanList/APIUsagePlanCard.tsx
+++ b/projects/ui/src/Components/UsagePlans/UsagePlanList/APIUsagePlanCard.tsx
@@ -89,16 +89,18 @@ export function APIUsagePlanCard({ api }: { api: API }) {
               message={`Getting information on usage plans for ${api.title}...`}
             />
           ) : (
-            <div className="usagePlansListContent">
-              {relevantUsagePlans.map((plan) => (
-                <ErrorBoundary
-                  key={plan.name}
-                  fallback={`There was an issue loading information about ${plan.name}`}
-                >
-                  <UsagePlanDetails apiId={api.apiId} usagePlan={plan} />
-                </ErrorBoundary>
-              ))}
-            </div>
+            relevantUsagePlans.length > 0 && (
+              <div className="usagePlansListContent">
+                {relevantUsagePlans.map((plan) => (
+                  <ErrorBoundary
+                    key={plan.name}
+                    fallback={`There was an issue loading information about ${plan.name}`}
+                  >
+                    <UsagePlanDetails apiId={api.apiId} usagePlan={plan} />
+                  </ErrorBoundary>
+                ))}
+              </div>
+            )
           )}
         </div>
       )}

--- a/projects/ui/src/Utility/backstage_demo_utility.ts
+++ b/projects/ui/src/Utility/backstage_demo_utility.ts
@@ -1,0 +1,40 @@
+import YAML from "yaml";
+import { API, APISchema } from "../Apis/api-types";
+
+function keyValue(theKey: string, ...theValues: (string | undefined)[]) {
+  let truthyValue = "";
+  for (let i = 0; i < theValues.length; i++) {
+    const cur = theValues[i];
+    if (cur !== undefined) {
+      truthyValue = cur;
+      break;
+    }
+  }
+  if (!truthyValue) return "";
+  else return theKey + ": " + truthyValue;
+}
+
+/**
+ * This tries to convert the API into a format that Backstage can consume.
+ * For documentation on the spec, see:
+ * https://backstage.io/docs/features/software-catalog/descriptor-format/#kind-api
+ */
+export function createBackstageYaml(apiSummary: API, apiSchema: APISchema) {
+  const meta = apiSummary.customMetadata;
+  const apiSchemaYamlStr = YAML.stringify(apiSchema);
+  return `apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: ${apiSummary.title.replaceAll(" ", "-")}
+  description: ${apiSummary.description}
+spec:
+  type: openapi
+  ${keyValue("owner", meta?.owner, apiSummary.contact)}
+  ${keyValue("lifecycle", meta?.lifecycle, "production")}
+  definition: |-
+    ${
+      // This is to add in the correct indentation.
+      apiSchemaYamlStr.replaceAll("\n", "\n    ")
+    }
+`;
+}

--- a/projects/ui/src/Utility/utility.ts
+++ b/projects/ui/src/Utility/utility.ts
@@ -28,3 +28,16 @@ export async function copyToClipboard(textToCopy: string) {
     }
   }
 }
+
+function download(filename: string, text: string) {
+  var element = document.createElement("a");
+  element.setAttribute(
+    "href",
+    "data:text/plain;charset=utf-8," + encodeURIComponent(text)
+  );
+  element.setAttribute("download", filename);
+  element.style.display = "none";
+  document.body.appendChild(element);
+  element.click();
+  document.body.removeChild(element);
+}

--- a/projects/ui/src/Utility/utility.ts
+++ b/projects/ui/src/Utility/utility.ts
@@ -29,15 +29,16 @@ export async function copyToClipboard(textToCopy: string) {
   }
 }
 
-function download(filename: string, text: string) {
-  var element = document.createElement("a");
-  element.setAttribute(
+export function downloadTextFile(filename: string, text: string) {
+  const el = document.createElement("a");
+  el.setAttribute(
     "href",
     "data:text/plain;charset=utf-8," + encodeURIComponent(text)
   );
-  element.setAttribute("download", filename);
-  element.style.display = "none";
-  document.body.appendChild(element);
-  element.click();
-  document.body.removeChild(element);
+  el.setAttribute("download", filename);
+  el.setAttribute("target", "_blank");
+  el.style.display = "none";
+  document.body.appendChild(el);
+  el.click();
+  document.body.removeChild(el);
 }

--- a/projects/ui/src/Utility/utility.ts
+++ b/projects/ui/src/Utility/utility.ts
@@ -29,7 +29,7 @@ export async function copyToClipboard(textToCopy: string) {
   }
 }
 
-export function downloadTextFile(filename: string, text: string) {
+export function downloadFile(filename: string, text: string) {
   const el = document.createElement("a");
   el.setAttribute(
     "href",

--- a/projects/ui/src/stories/api-details/ApiDetailsPage.stories.tsx
+++ b/projects/ui/src/stories/api-details/ApiDetailsPage.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { DiProvider, injectable } from "react-magnetic-di";
+import { DeepPartialObject, DiProvider, injectable } from "react-magnetic-di";
 import { MemoryRouter, useParams } from "react-router-dom";
-import { useGetApiDetails } from "../../Apis/hooks";
+import { API } from "../../Apis/api-types";
+import { useGetApiDetails, useListApis } from "../../Apis/hooks";
 import { ApiDetailsPage } from "../../Components/ApiDetails/ApiDetailsPage";
 import { appContentDecorator } from "../decorators/decorators";
 import exampleOpenApiSchema from "./exampleOpenApiSchema";
@@ -23,6 +24,15 @@ type Story = StoryObj<typeof meta>;
 // This uses an example schema from the OpenApi-Specification repository:
 // https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v2.0/json/uber.json
 //
+const mockApisList: DeepPartialObject<API>[] = [
+  {
+    apiId: "uber-api",
+    contact: "uber-api-contact",
+    customMetadata: {},
+    description: "A mock API.",
+    title: "Uber API",
+  },
+];
 export const Default: Story = {
   decorators: [
     appContentDecorator,
@@ -32,11 +42,15 @@ export const Default: Story = {
         data: exampleOpenApiSchema,
       }));
       const useParamsDi = injectable(useParams, () => ({
-        apiId: "swagger-petstore",
+        apiId: mockApisList[0].apiId,
+      }));
+      const useListApisDi = injectable(useListApis, () => ({
+        isLoading: false,
+        data: mockApisList,
       }));
       return (
         <MemoryRouter>
-          <DiProvider use={[useGetApiDetailsDi, useParamsDi]}>
+          <DiProvider use={[useGetApiDetailsDi, useParamsDi, useListApisDi]}>
             <Story />
           </DiProvider>
         </MemoryRouter>

--- a/projects/ui/yarn.lock
+++ b/projects/ui/yarn.lock
@@ -9902,6 +9902,11 @@ yaml@^2.2.1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
   integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
 
+yaml@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
+
 yargs-parser@^20.2.2, yargs-parser@^20.2.9:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"


### PR DESCRIPTION
This adds some starter code for exporting APIs in a format that Backstage can import, and includes a small style fix on the usage plans page.

See the linked issue for screenshots and context

Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/7416