### PR TITLE
one-line login-check fix for the latest portal updates

### DIFF
--- a/projects/ui/src/Components/Structure/LoggedInUser.tsx
+++ b/projects/ui/src/Components/Structure/LoggedInUser.tsx
@@ -23,7 +23,8 @@ export function LoggedInUser() {
   // eslint-disable-next-line no-console
   console.log(user);
 
-  return !user ? (
+  const isLoggedIn = !!user?.email || !!user?.username || !!user?.name;
+  return !isLoggedIn ? (
     <div className="userLoginArea loggedOut">
       <a href={`${restpointPrefix}/login`}>
         <div className="styledButton">LOGIN</div>


### PR DESCRIPTION
The API now returns `{"message": "User not authenticated"}`, which causes our current login check to not work. This PR fixes that to make sure any of the user fields are set before setting `loggedIn=true`.