### PR TITLE
Fixed docker image network errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM --platform=linux/amd64 node:16
 COPY ./projects/ui/dist ./dist
 WORKDIR .
-ENTRYPOINT ["npx", "vite@4.2.1", "preview", "--port", "4000"]
+RUN ["npm", "install", "vite@4.2.1", "-g"]
+ENTRYPOINT ["vite", "preview", "--port", "4000"]


### PR DESCRIPTION
There was an issue with the ENTRYPOINT command executing network requests and failing when running the container. The RUN command executes while building the image, so moving the network requests to the RUN command fixed an issue with the image deployment.