### PR TITLE
Added swagger fix for apis with periods in their name.

### DIFF
--- a/projects/ui/src/Components/ApiDetails/SwaggerDisplay.tsx
+++ b/projects/ui/src/Components/ApiDetails/SwaggerDisplay.tsx
@@ -1,7 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import SwaggerUIConstructor from "swagger-ui";
 import "swagger-ui/dist/swagger-ui.css";
 import { APISchema } from "../../Apis/api-types";
+
+const sanitize = (id: string) => id.replaceAll(".", "-");
 
 export function SwaggerDisplay({
   spec,
@@ -10,15 +12,27 @@ export function SwaggerDisplay({
   spec: APISchema | undefined;
   apiId: string;
 }) {
+  // The sanitized dom_id, where all periods are replaced with dashes. This fixes issues where Swagger tries
+  // doing a `querySelector` which fails, due to it treating the period as a class selector, and not part of the ID itself.
+  const [sanitizedDomId, setSanitizedDomId] = useState<string>(sanitize(apiId));
+  useEffect(() => {
+    const newSanitizedId = sanitize(apiId);
+    if (sanitizedDomId !== newSanitizedId) {
+      setSanitizedDomId(newSanitizedId);
+    }
+  }, [apiId, sanitizedDomId]);
+
   useEffect(() => {
     SwaggerUIConstructor({
       spec: spec,
-      dom_id: `#display-swagger-${apiId}`,
+      dom_id: `#display-swagger-${sanitizedDomId}`,
       withCredentials: true,
       deepLinking: true,
       syntaxHighlight: { activate: false },
     });
-  }, [apiId]);
+  }, [sanitizedDomId, spec]);
 
-  return <div aria-label="Schema Display" id={`display-swagger-${apiId}`} />;
+  return (
+    <div aria-label="Schema Display" id={`display-swagger-${sanitizedDomId}`} />
+  );
 }

--- a/projects/ui/src/user_variables.tmplr.ts
+++ b/projects/ui/src/user_variables.tmplr.ts
@@ -43,8 +43,7 @@ document.title = companyName + " Portal";
  */
 export const tokenEndpoint = templateString(
   "{{ tmplr.tokenEndpoint }}",
-  import.meta.env.VITE_TOKEN_ENDPOINT,
-  "https://f983-2600-1700-1e17-8010-1434-ceb1-8a68-cb20.ngrok-free.app/auth/realms/master/protocol/openid-connect/token"
+  import.meta.env.VITE_TOKEN_ENDPOINT
 );
 
 /**
@@ -54,8 +53,7 @@ export const tokenEndpoint = templateString(
  */
 export const clientId = templateString(
   "{{ tmplr.clientId }}",
-  import.meta.env.VITE_CLIENT_ID,
-  "17daa3f6-9c0f-41c6-a620-62082da22f94"
+  import.meta.env.VITE_CLIENT_ID
 );
 
 /**
@@ -65,6 +63,5 @@ export const clientId = templateString(
  */
 export const clientSecret = templateString(
   "{{ tmplr.clientSecret }}",
-  import.meta.env.VITE_CLIENT_SECRET,
-  "19e4265d-5a68-406c-bb77-8f487da1fb3f"
+  import.meta.env.VITE_CLIENT_SECRET
 );


### PR DESCRIPTION
This includes the bug fix from https://github.com/solo-io/dev-portal/pull/2709 since the dev-portal starter also uses the swagger UI.

Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/9773