### PR TITLE
Added github workflow for branching on releases.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - created
 
 jobs:
-  branchAndPublish:
+  branch:
     runs-on: ubuntu-20.04
 
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,14 +10,32 @@ jobs:
     runs-on: ubuntu-20.04
 
     env:
-      REPO_VERSION: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      GCLOUD_AUTH_KEY: ${{ secrets.GC_PUBLIC_GCR_SA_KEY }}
 
     steps:
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: solo-public
+          service_account_key: $GCLOUD_AUTH_KEY
+          export_default_credentials: true
+
+      - name: Configure Docker to use GCR
+        run: |
+          gcloud auth configure-docker --quiet
+
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Create release branch
         run: |
-          RELEASE_NUMBER=$(echo $REPO_VERSION | sed 's|\.[0-9]*$|\.x|g')
+          RELEASE_NUMBER=$(echo $RELEASE_TAG | sed 's|\.[0-9]*$|\.x|g')
           git checkout -b $RELEASE_NUMBER
           git push origin $RELEASE_NUMBER
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t gcr.io/solo-public/portal-frontend:${RELEASE_TAG} .
+          docker push gcr.io/solo-public/portal-frontend:${RELEASE_TAG}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release Workflow
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  branchAndPublish:
+    runs-on: ubuntu-20.04
+
+    env:
+      REPO_VERSION: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Create release branch
+        run: |
+          RELEASE_NUMBER=$(echo $REPO_VERSION | sed 's|\.[0-9]*$|\.x|g')
+          git checkout -b $RELEASE_NUMBER
+          git push origin $RELEASE_NUMBER


### PR DESCRIPTION
Issue link: https://github.com/solo-io/gloo-mesh-enterprise/issues/10068

Currently this just branches the repo on release and does not build or push an image.