### PR TITLE
Scaffolding for apps and teams pages

### DIFF
--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -51,6 +51,28 @@ export type APIProduct = {
   apiVersions: APIVersion[];
 };
 
+export type App = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  name: string;
+  description: string;
+  idpClientName: string;
+  idpClientId: string;
+  idpClientSecret: string;
+  teamId: string;
+};
+
+export type Team = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  name: string;
+  description: string;
+};
+
 type SchemaPropertyType = "string" | "integer" | "array" | "object";
 export type APISchema = {
   components?: {

--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -73,6 +73,17 @@ export type Team = {
   description: string;
 };
 
+export type Member = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  email: string;
+  name: string;
+  username: string;
+  synced: boolean;
+};
+
 type SchemaPropertyType = "string" | "integer" | "array" | "object";
 export type APISchema = {
   components?: {

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -2,7 +2,15 @@ import { useContext } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import useSWRMutation from "swr/mutation";
 import { PortalAuthContext } from "../Context/PortalAuthContext";
-import { APIKey, APIProduct, APISchema, UsagePlan, User } from "./api-types";
+import {
+  APIKey,
+  APIProduct,
+  APISchema,
+  App,
+  Team,
+  UsagePlan,
+  User,
+} from "./api-types";
 
 let _portalServerUrl = import.meta.env.VITE_PORTAL_SERVER_URL;
 if (
@@ -72,6 +80,12 @@ export function useGetCurrentUser() {
 
 export function useListApis() {
   return useSwrWithAuth<APIProduct[]>("/apis");
+}
+export function useListApps(teamId: string) {
+  return useSwrWithAuth<App[]>(`/teams/${teamId}/apps`);
+}
+export function useListTeams() {
+  return useSwrWithAuth<Team[]>(`/teams`);
 }
 export function useGetApiDetails(id?: string) {
   return useSwrWithAuth<APISchema>(`/apis/${id}/schema`);

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -7,6 +7,7 @@ import {
   APIProduct,
   APISchema,
   App,
+  Member,
   Team,
   UsagePlan,
   User,
@@ -93,6 +94,9 @@ export function useListApis() {
 }
 export function useListApps(teamId: string) {
   return useSwrWithAuth<App[]>(`/teams/${teamId}/apps`);
+}
+export function useListMembers(teamId: string) {
+  return useSwrWithAuth<Member[]>(`/teams/${teamId}/members`);
 }
 export function useListTeams() {
   return useSwrWithAuth<Team[]>(`/teams`);

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -32,6 +32,12 @@ async function fetchJSON(...args: Parameters<typeof fetch>) {
       ...args[1],
       headers: {
         ...args[1]?.headers,
+        // TODO: Could remove this once auth is working.
+        ...(import.meta.env.VITE_AUTH_HEADER
+          ? {
+              Authorization: import.meta.env.VITE_AUTH_HEADER,
+            }
+          : {}),
         "Content-Type": "application/json",
       },
     },
@@ -58,7 +64,11 @@ const useSwrWithAuth = <T>(
     (...args) => {
       return fetchJSON(args[0], {
         ...(args.length > 1 && !!args[1] ? args[1] : {}),
-        credentials: "include",
+        // credentials: "include",
+        // Removing "credentials: include", since the server's 'Access-Control-Allow-Origin' header is "*".
+        // If this is kept in, there is a browser error:
+        //   The value of the 'Access-Control-Allow-Origin' header in the response must not be
+        //   the wildcard '*' when the request's credentials mode is 'include'
         headers: {
           ...(args.length > 1 && args[1].headers ? args[1].headers : {}),
           ...authHeaders,

--- a/projects/ui/src/Assets/Icons/Icons.tsx
+++ b/projects/ui/src/Assets/Icons/Icons.tsx
@@ -30,6 +30,7 @@ export { ReactComponent as SmallX } from "./small-x.svg";
 export { ReactComponent as Speedometer } from "./speedometer.svg";
 export { ReactComponent as SuccessCheckmark } from "./success-checkmark.svg";
 export { ReactComponent as Tag } from "./tag-icon.svg";
+export { ReactComponent as TeamsIcon } from "./teams-icon.svg";
 export { ReactComponent as TileViewIcon } from "./tile-view.svg";
 export { ReactComponent as UpArrow } from "./up-arrow.svg";
 export { ReactComponent as UpstreamRipple } from "./upstream-ripple.svg";

--- a/projects/ui/src/Assets/Icons/Icons.tsx
+++ b/projects/ui/src/Assets/Icons/Icons.tsx
@@ -32,6 +32,7 @@ export { ReactComponent as SuccessCheckmark } from "./success-checkmark.svg";
 export { ReactComponent as Tag } from "./tag-icon.svg";
 export { ReactComponent as TeamsIcon } from "./teams-icon.svg";
 export { ReactComponent as TileViewIcon } from "./tile-view.svg";
+export { ReactComponent as UserIcon } from "./user-icon.svg";
 export { ReactComponent as UpArrow } from "./up-arrow.svg";
 export { ReactComponent as UpstreamRipple } from "./upstream-ripple.svg";
 export { ReactComponent as UserProfile } from "./profile-icon.svg";

--- a/projects/ui/src/Assets/Icons/teams-icon.svg
+++ b/projects/ui/src/Assets/Icons/teams-icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <g id="teams-icon" transform="translate(-1128 -621)">
+    <g id="Rectangle_8411" data-name="Rectangle 8411" transform="translate(1128 621)" fill="#158bc2" stroke="#158bc2" stroke-width="0.5" opacity="0">
+      <rect width="20" height="20" stroke="none"/>
+      <rect x="0.25" y="0.25" width="19.5" height="19.5" fill="none"/>
+    </g>
+    <g id="noun-5158515" transform="translate(1065.5 411.291)">
+      <path id="Path_107885" data-name="Path 107885" d="M419.477,215.988a3.488,3.488,0,1,0-3.488,3.488A3.49,3.49,0,0,0,419.477,215.988Zm-1.4,0a2.093,2.093,0,1,1-2.093-2.093A2.094,2.094,0,0,1,418.081,215.988Z" transform="translate(-343.488 0)" fill="#158bc2" fill-rule="evenodd"/>
+      <path id="Path_107886" data-name="Path 107886" d="M317.849,612.5a5.349,5.349,0,0,0-5.349,5.349v.93a.7.7,0,0,0,.7.7h9.3a.7.7,0,0,0,.7-.7v-.93A5.349,5.349,0,0,0,317.849,612.5Zm0,1.4a3.953,3.953,0,0,1,3.953,3.953v.233H313.9v-.233A3.953,3.953,0,0,1,317.849,613.9Z" transform="translate(-245.349 -392.558)" fill="#158bc2" fill-rule="evenodd"/>
+      <path id="Path_107887" data-name="Path 107887" d="M790.644,390.1a2.6,2.6,0,1,0-2.6,2.6A2.6,2.6,0,0,0,790.644,390.1Zm-1.4,0a1.2,1.2,0,1,1-1.2-1.2A1.2,1.2,0,0,1,789.248,390.1Z" transform="translate(-709.5 -171.744)" fill="#158bc2" fill-rule="evenodd"/>
+      <path id="Path_107888" data-name="Path 107888" d="M713.2,699.46h6.512a.7.7,0,0,0,.7-.7v-.819A3.949,3.949,0,0,0,716.454,694a.7.7,0,1,0,0,1.4,2.554,2.554,0,0,1,2.558,2.549v.121H713.2a.7.7,0,0,0,0,1.4Z" transform="translate(-637.907 -472.542)" fill="#158bc2" fill-rule="evenodd"/>
+      <path id="Path_107889" data-name="Path 107889" d="M140.644,390.1a2.6,2.6,0,1,0-2.6,2.6A2.6,2.6,0,0,0,140.644,390.1Zm-1.4,0a1.2,1.2,0,1,1-1.2-1.2A1.2,1.2,0,0,1,139.248,390.1Z" transform="translate(-71.593 -171.744)" fill="#158bc2" fill-rule="evenodd"/>
+      <path id="Path_107890" data-name="Path 107890" d="M69.709,698.065H63.9v-.121a2.554,2.554,0,0,1,2.558-2.549.7.7,0,1,0,0-1.4,3.949,3.949,0,0,0-3.954,3.944v.819a.7.7,0,0,0,.7.7h6.512a.7.7,0,1,0,0-1.4Z" transform="translate(0 -472.542)" fill="#158bc2" fill-rule="evenodd"/>
+    </g>
+  </g>
+</svg>

--- a/projects/ui/src/Assets/Icons/user-icon.svg
+++ b/projects/ui/src/Assets/Icons/user-icon.svg
@@ -1,0 +1,10 @@
+<svg id="User_icon" data-name="User icon" xmlns="http://www.w3.org/2000/svg" width="23" height="23" viewBox="0 0 23 23">
+  <g id="Rectangle_8411" data-name="Rectangle 8411" fill="#158bc2" stroke="#158bc2" stroke-width="0.5" opacity="0">
+    <rect width="23" height="23" stroke="none"/>
+    <rect x="0.25" y="0.25" width="22.5" height="22.5" fill="none"/>
+  </g>
+  <g id="member-icon" transform="translate(2.468 2.468)">
+    <path id="Path_38338" data-name="Path 38338" d="M14.032,55C8.974,55,5,56.987,5,59.516v3.011a.5.5,0,0,0,.5.5h17.06a.5.5,0,0,0,.5-.5V59.516C23.064,56.987,19.09,55,14.032,55Zm8.028,7.025H6V59.516C6,57.81,9.235,56,14.032,56s8.028,1.806,8.028,3.512Z" transform="translate(-5 -44.964)" fill="#158bc2" stroke="#158bc2" stroke-width="0.5"/>
+    <path id="Path_38339" data-name="Path 38339" d="M36.532,9.516a4.516,4.516,0,1,0-4.516,4.516A4.523,4.523,0,0,0,36.532,9.516Zm-8.028,0a3.512,3.512,0,1,1,3.512,3.512A3.529,3.529,0,0,1,28.5,9.516Z" transform="translate(-22.984 -5)" fill="#158bc2" stroke="#158bc2" stroke-width="0.5"/>
+  </g>
+</svg>

--- a/projects/ui/src/Components/Apis/ApisTab/ApiSummaryCards/ApiSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApiSummaryCards/ApiSummaryGridCard.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { APIProduct } from "../../../../Apis/api-types";
 import { Icon } from "../../../../Assets/Icons";
+import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
+import { getApiDetailsLink } from "../../../../Utility/link-builders";
 import { DataPairPill, DataPairPillList } from "../../../Common/DataPairPill";
-import { getApiDetailsLink } from "../../helpers";
-import { ApiSummaryGridCardStyles } from "./ApiSummaryGridCard.style";
 
 /**
  * MAIN COMPONENT
@@ -24,7 +24,7 @@ export function ApiSummaryGridCard({ api }: { api: APIProduct }) {
   );
 
   return (
-    <ApiSummaryGridCardStyles.ApiGridCardWithLink to={getApiDetailsLink(api)}>
+    <GridCardStyles.GridCardWithLink to={getApiDetailsLink(api)}>
       <div className="content">
         <div className="apiImageHolder">
           <img src={defaultCardImage} alt="" role="banner" />
@@ -77,6 +77,6 @@ export function ApiSummaryGridCard({ api }: { api: APIProduct }) {
           <Icon.OpenApiIcon />
         </div>
       </div>
-    </ApiSummaryGridCardStyles.ApiGridCardWithLink>
+    </GridCardStyles.GridCardWithLink>
   );
 }

--- a/projects/ui/src/Components/Apis/ApisTab/ApiSummaryCards/ApiSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApiSummaryCards/ApiSummaryListCard.tsx
@@ -1,9 +1,9 @@
 import { NavLink } from "react-router-dom";
 import { APIProduct } from "../../../../Apis/api-types";
 import { Icon } from "../../../../Assets/Icons";
+import { ListCardStyles } from "../../../../Styles/shared/ListCard.style";
+import { getApiDetailsLink } from "../../../../Utility/link-builders";
 import { DataPairPill, DataPairPillList } from "../../../Common/DataPairPill";
-import { getApiDetailsLink } from "../../helpers";
-import { ApiSummaryListCardStyles } from "./ApiSummaryListCard.style";
 
 /**
  * MAIN COMPONENT
@@ -11,7 +11,7 @@ import { ApiSummaryListCardStyles } from "./ApiSummaryListCard.style";
 export function ApiSummaryListCard({ api }: { api: APIProduct }) {
   return (
     <NavLink to={getApiDetailsLink(api)}>
-      <ApiSummaryListCardStyles.ApiListCardWithLink>
+      <ListCardStyles.ListCardWithLink>
         <div className="content">
           <div className="majorIconHolder">
             <Icon.WrenchGear className="colorIt" />
@@ -67,7 +67,7 @@ export function ApiSummaryListCard({ api }: { api: APIProduct }) {
             <Icon.OpenApiIcon />
           </div>
         </div>
-      </ApiSummaryListCardStyles.ApiListCardWithLink>
+      </ListCardStyles.ListCardWithLink>
     </NavLink>
   );
 }

--- a/projects/ui/src/Components/Apis/ApisTab/ApisList.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApisList.tsx
@@ -1,12 +1,16 @@
 import { useMemo } from "react";
 import { di } from "react-magnetic-di";
 import { useListApis } from "../../../Apis/hooks";
+import {
+  FilterPair,
+  FilterType,
+  parsePairString,
+} from "../../../Utility/filter-utility";
 import { EmptyData } from "../../Common/EmptyData";
 import { Loading } from "../../Common/Loading";
 import { ApisPageStyles } from "../ApisPage.style";
 import { ApiSummaryGridCard } from "./ApiSummaryCards/ApiSummaryGridCard";
 import { ApiSummaryListCard } from "./ApiSummaryCards/ApiSummaryListCard";
-import { FilterPair, FilterType, parsePairString } from "./ApisFilter";
 
 export function ApisList({
   allFilters,

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style.tsx
@@ -40,7 +40,26 @@ export namespace SubscriptionInfoCardStyles {
       font-size: 0.95rem;
       gap: 10px;
       a {
+        position: relative;
         font-weight: 500;
+        padding-right: 5px;
+        :hover {
+          color: ${theme.seaBlue};
+          text-decoration: underline;
+        }
+        :active {
+          color: ${theme.oceanBlue};
+        }
+        :after {
+          content: "";
+          border-top: 2px solid;
+          border-right: 2px solid;
+          border-color: currentColor;
+          width: 10px;
+          height: 10px;
+          display: inline-block;
+          transform: translateX(2px) rotate(45deg);
+        }
       }
     `
   );
@@ -49,6 +68,13 @@ export namespace SubscriptionInfoCardStyles {
     font-size: 1.5rem;
     font-weight: bold;
     margin-bottom: 2px;
+  `;
+
+  export const CardTitleSmall = styled.div`
+    font-size: 1.25rem;
+    font-weight: bold;
+    margin-bottom: 2px;
+    text-align: left;
   `;
 
   export const SubscriptionCardBadge = styled.div<{

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
@@ -4,8 +4,8 @@ import { di } from "react-magnetic-di";
 import { NavLink } from "react-router-dom";
 import { useListApis } from "../../../Apis/hooks";
 import { AppIcon } from "../../../Assets/Icons/Icons";
+import { getApiDetailsLink } from "../../../Utility/link-builders";
 import { Subscription, subscriptionStateMap } from "../ApisPage";
-import { getApiDetailsLink } from "../helpers";
 import { SubscriptionInfoCardStyles as Styles } from "./SubscriptionInfoCard.style";
 
 const SubscriptionInfoCard = ({

--- a/projects/ui/src/Components/AppContentRoutes.tsx
+++ b/projects/ui/src/Components/AppContentRoutes.tsx
@@ -6,10 +6,12 @@ import {
 } from "../user_variables.tmplr";
 import { ApiDetailsPage } from "./ApiDetails/ApiDetailsPage";
 import { ApisPage } from "./Apis/ApisPage";
+import { AppsPage } from "./Apps/AppsPage";
 import { ErrorBoundary } from "./Common/ErrorBoundary";
 import LoggedOut from "./Common/LoggedOut";
 import { HomePage } from "./Home/HomePage";
 import { Footer } from "./Structure/Footer";
+import { TeamsPage } from "./Teams/TeamsPage";
 
 const MainContentContainer = styled.div`
   grid-area: contentcontainer;
@@ -65,6 +67,22 @@ function AppContentRoutes() {
           element={
             <ErrorBoundary fallback="There was an issue displaying the list of APIs">
               <ApisPage />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/apps"
+          element={
+            <ErrorBoundary fallback="There was an issue displaying the list of Apps">
+              <AppsPage />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/teams"
+          element={
+            <ErrorBoundary fallback="There was an issue displaying the list of Teams">
+              <TeamsPage />
             </ErrorBoundary>
           }
         />

--- a/projects/ui/src/Components/Apps/AppsPage.style.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.style.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export namespace AppsPageStyles {
+  export const AppGridList = styled.div`
+    display: grid;
+    grid-gap: 30px;
+    grid-template-columns: 1fr 1fr 1fr;
+  `;
+}

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -1,5 +1,5 @@
 import { di } from "react-magnetic-di";
-import { useListApis, useListApps } from "../../Apis/hooks";
+import { useListTeams } from "../../Apis/hooks";
 import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
@@ -8,8 +8,8 @@ import { PageContainer } from "../Common/PageContainer";
 import { AppsPageContent } from "./PageContent/AppsPageContent";
 
 export function AppsPage() {
-  di(useListApis);
-  const { isLoading } = useListApps("abc");
+  di(useListTeams);
+  const { isLoading } = useListTeams();
 
   return (
     <PageContainer>
@@ -20,8 +20,8 @@ export function AppsPage() {
       />
 
       {isLoading ? (
-        // Make sure the APIs are finished loading since they are a dependency of both tabs.
-        <Loading message="Getting list of apps..." />
+        // Make sure the teams are finished loading since they are a dependency.
+        <Loading message="Loading..." />
       ) : (
         <AppsPageContent />
       )}

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -1,0 +1,5 @@
+const AppsPage = () => {
+  return <div>AppsPage</div>;
+};
+
+export default AppsPage;

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -1,5 +1,30 @@
-const AppsPage = () => {
-  return <div>AppsPage</div>;
-};
+import { di } from "react-magnetic-di";
+import { useListApis, useListApps } from "../../Apis/hooks";
+import { Icon } from "../../Assets/Icons";
+import { BannerHeading } from "../Common/Banner/BannerHeading";
+import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
+import { Loading } from "../Common/Loading";
+import { PageContainer } from "../Common/PageContainer";
+import { AppsPageContent } from "./PageContent/AppsPageContent";
 
-export default AppsPage;
+export function AppsPage() {
+  di(useListApis);
+  const { isLoading } = useListApps("abc");
+
+  return (
+    <PageContainer>
+      <BannerHeading
+        title={<BannerHeadingTitle text={"Apps"} logo={<Icon.AppIcon />} />}
+        description={"Browse the list of Apps in this portal."}
+        breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Apps" }]}
+      />
+
+      {isLoading ? (
+        // Make sure the APIs are finished loading since they are a dependency of both tabs.
+        <Loading message="Getting list of apps..." />
+      ) : (
+        <AppsPageContent />
+      )}
+    </PageContainer>
+  );
+}

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -36,7 +36,6 @@ export function AppSummaryGridCard({ app }: { app: App }) {
       </div>
       <div className="footer">
         <div className="metaInfo">
-          <Icon.SmallCodeGear />
           <div className="typeTitle" aria-label="API Type">
             {/* 
             // TODO: Add in team info from listTeams()

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+import { App } from "../../../../Apis/api-types";
+import { Icon } from "../../../../Assets/Icons";
+import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
+import { getAppDetailsLink } from "../../../../Utility/link-builders";
+
+/**
+ * MAIN COMPONENT
+ **/
+export function AppSummaryGridCard({ app }: { app: App }) {
+  // In the future banner images may come through API data.
+  //   Even when that is the case, a default image may be desired
+  //   for when no image is available.
+  // Further, you may have some clever trick for setting one of
+  //   many default images.
+  const defaultCardImage = useMemo(
+    () => {
+      return "https://img.huffingtonpost.com/asset/57f2730f170000f70aac9059.jpeg?ops=scalefit_960_noupscale";
+    },
+    // Currently we don't need to change images unless the api itself has changed.
+    //   Depending on the function within the memo, this may not always be the case.
+    [app.id]
+  );
+
+  return (
+    <GridCardStyles.GridCardWithLink to={getAppDetailsLink(app)}>
+      <div className="content">
+        <div className="apiImageHolder">
+          <img src={defaultCardImage} alt="" role="banner" />
+        </div>
+        <div className="details">
+          <div>
+            <h4 className="title">{app.name}</h4>
+          </div>
+        </div>
+      </div>
+      <div className="footer">
+        <div className="metaInfo">
+          <Icon.SmallCodeGear />
+          <div className="typeTitle" aria-label="API Type">
+            {/* 
+            // TODO: Add in team info from listTeams()
+            */}
+            Team: {app.teamId}
+          </div>
+        </div>
+        <div className="typeIcon">
+          <Icon.TeamsIcon />
+        </div>
+      </div>
+    </GridCardStyles.GridCardWithLink>
+  );
+}

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -36,15 +36,13 @@ export function AppSummaryGridCard({ app }: { app: App }) {
       </div>
       <div className="footer">
         <div className="metaInfo">
+          <Icon.TeamsIcon />
           <div className="typeTitle" aria-label="API Type">
             {/* 
             // TODO: Add in team info from listTeams()
             */}
-            Team: {app.teamId}
+            Team
           </div>
-        </div>
-        <div className="typeIcon">
-          <Icon.TeamsIcon />
         </div>
       </div>
     </GridCardStyles.GridCardWithLink>

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
@@ -23,14 +23,11 @@ export function AppSummaryListCard({ app }: { app: App }) {
         </div>
         <div className="footer">
           <div className="metaInfo">
-            <Icon.SmallCodeGear />
+            <Icon.TeamsIcon />
             {/* 
             // TODO: Add in team info from listTeams()
             */}
             Team: {app.teamId}
-          </div>
-          <div className="typeIcon">
-            <Icon.TeamsIcon />
           </div>
         </div>
       </ListCardStyles.ListCardWithLink>

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
@@ -1,0 +1,39 @@
+import { NavLink } from "react-router-dom";
+import { App } from "../../../../Apis/api-types";
+import { Icon } from "../../../../Assets/Icons";
+import { ListCardStyles } from "../../../../Styles/shared/ListCard.style";
+import { getAppDetailsLink } from "../../../../Utility/link-builders";
+
+/**
+ * MAIN COMPONENT
+ **/
+export function AppSummaryListCard({ app }: { app: App }) {
+  return (
+    <NavLink to={getAppDetailsLink(app)}>
+      <ListCardStyles.ListCardWithLink>
+        <div className="content">
+          <div className="majorIconHolder">
+            <Icon.WrenchGear className="colorIt" />
+          </div>
+          <div className="details">
+            <div>
+              <h4 className="title">{app.name}</h4>
+            </div>
+          </div>
+        </div>
+        <div className="footer">
+          <div className="metaInfo">
+            <Icon.SmallCodeGear />
+            {/* 
+            // TODO: Add in team info from listTeams()
+            */}
+            Team: {app.teamId}
+          </div>
+          <div className="typeIcon">
+            <Icon.TeamsIcon />
+          </div>
+        </div>
+      </ListCardStyles.ListCardWithLink>
+    </NavLink>
+  );
+}

--- a/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
@@ -1,19 +1,13 @@
-import { Select, TextInput } from "@mantine/core";
-import { useState } from "react";
+import { TextInput } from "@mantine/core";
 import { Icon } from "../../../Assets/Icons";
 import { FilterStyles as Styles } from "../../../Styles/shared/Filters.style";
-import {
-  FilterPair,
-  FilterType,
-  getPairString,
-} from "../../../Utility/filter-utility";
-import { KeyValuePair } from "../../Common/DataPairPill";
+import { FilterPair, FilterType } from "../../../Utility/filter-utility";
 import GridListToggle from "../../Common/GridListToggle";
 
 /**
  * MAIN COMPONENT
  **/
-type ApisFiltrationProp = {
+type AppsFiltrationProp = {
   showingGrid: boolean;
   allFilters: FilterPair[];
   setAllFilters: (newFiltersList: FilterPair[]) => void;
@@ -22,11 +16,11 @@ type ApisFiltrationProp = {
   setNameFilter: (newNamesList: string) => void;
 };
 
-export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
-  const [pairFilter, setPairFilter] = useState<KeyValuePair>({
-    pairKey: "",
-    value: "",
-  });
+export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
+  // const [pairFilter, setPairFilter] = useState<KeyValuePair>({
+  //   pairKey: "",
+  //   value: "",
+  // });
 
   const addNameFilter = (evt: { target: { value: string } }) => {
     const displayName = evt.target.value;
@@ -46,45 +40,45 @@ export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
     filters.setNameFilter("");
   };
 
-  const alterPairKey = (evt: React.ChangeEvent<HTMLInputElement>) => {
-    const newKey = evt.target.value;
-    setPairFilter({
-      pairKey: newKey,
-      value: pairFilter.value,
-    });
-  };
-  const alterKeyValuePair = (evt: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = evt.target.value;
-    setPairFilter({
-      pairKey: pairFilter.pairKey,
-      value: newValue,
-    });
-  };
+  // const alterPairKey = (evt: React.ChangeEvent<HTMLInputElement>) => {
+  //   const newKey = evt.target.value;
+  //   setPairFilter({
+  //     pairKey: newKey,
+  //     value: pairFilter.value,
+  //   });
+  // };
+  // const alterKeyValuePair = (evt: React.ChangeEvent<HTMLInputElement>) => {
+  //   const newValue = evt.target.value;
+  //   setPairFilter({
+  //     pairKey: pairFilter.pairKey,
+  //     value: newValue,
+  //   });
+  // };
 
-  const addKeyValuePairFilter = () => {
-    const displayName = getPairString(pairFilter);
-    if (displayName.trim() === ":") return;
-    // Check for duplicate filters.
-    const isDuplicateFilter = filters.allFilters.some(
-      (f) => f.type === FilterType.keyValuePair && f.displayName === displayName
-    );
-    if (isDuplicateFilter) {
-      return;
-    }
-    filters.setAllFilters([
-      ...filters.allFilters,
-      { displayName, type: FilterType.keyValuePair },
-    ]);
+  // const addKeyValuePairFilter = () => {
+  //   const displayName = getPairString(pairFilter);
+  //   if (displayName.trim() === ":") return;
+  //   // Check for duplicate filters.
+  //   const isDuplicateFilter = filters.allFilters.some(
+  //     (f) => f.type === FilterType.keyValuePair && f.displayName === displayName
+  //   );
+  //   if (isDuplicateFilter) {
+  //     return;
+  //   }
+  //   filters.setAllFilters([
+  //     ...filters.allFilters,
+  //     { displayName, type: FilterType.keyValuePair },
+  //   ]);
 
-    setPairFilter({ pairKey: "", value: "" });
-  };
+  //   setPairFilter({ pairKey: "", value: "" });
+  // };
 
-  const addTypeFilter = (addedType: string) => {
-    filters.setAllFilters([
-      ...filters.allFilters,
-      { displayName: addedType, type: FilterType.apiType },
-    ]);
-  };
+  // const addTypeFilter = (addedType: string) => {
+  //   filters.setAllFilters([
+  //     ...filters.allFilters,
+  //     { displayName: addedType, type: FilterType.apiType },
+  //   ]);
+  // };
 
   const removeFilter = (filterPair: FilterPair) => {
     filters.setAllFilters(
@@ -100,19 +94,19 @@ export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
     filters.setAllFilters([]);
   };
 
-  const selectableTypes = [
-    {
-      label: "OpenAPI",
-      value: "OpenAPI",
-    },
-  ].filter(
-    (selectableType) =>
-      !filters.allFilters.some(
-        (filter) =>
-          filter.type === FilterType.apiType &&
-          filter.displayName === selectableType.value
-      )
-  );
+  // const selectableTypes = [
+  //   {
+  //     label: "OpenAPI",
+  //     value: "OpenAPI",
+  //   },
+  // ].filter(
+  //   (selectableType) =>
+  //     !filters.allFilters.some(
+  //       (filter) =>
+  //         filter.type === FilterType.apiType &&
+  //         filter.displayName === selectableType.value
+  //     )
+  // );
 
   return (
     <Styles.FilterArea>
@@ -133,6 +127,8 @@ export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
           />
           <Icon.MagnifyingGlass style={{ pointerEvents: "none" }} />
         </form>
+        {/*
+        
         <form
           onSubmit={(e) => {
             e.preventDefault();
@@ -163,8 +159,8 @@ export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
               <Icon.Add />
             </button>
           </div>
-        </form>
-        <div className="dropdownFilter">
+        </form> */}
+        {/* <div className="dropdownFilter">
           <div className="gearHolder">
             <Icon.CodeGear />
           </div>
@@ -177,7 +173,8 @@ export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
             value=""
             placeholder="API Type"
           />
-        </div>
+        </div> */}
+
         <GridListToggle
           onChange={(newIsList) => filters.setShowingGrid(!newIsList)}
           isList={!filters.showingGrid}

--- a/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { di } from "react-magnetic-di";
 import { useListApps } from "../../../Apis/hooks";
-import { FilterPair } from "../../../Utility/filter-utility";
+import { FilterPair, FilterType } from "../../../Utility/filter-utility";
 import { EmptyData } from "../../Common/EmptyData";
 import { Loading } from "../../Common/Loading";
 import { AppsPageStyles } from "../AppsPage.style";
@@ -30,29 +30,25 @@ export function AppsList({
       return [];
     }
     return appsList
-      .filter((api) => {
+      .filter((app) => {
         let passesNameFilter =
           !nameFilter ||
-          api.name.toLocaleLowerCase().includes(nameFilter.toLocaleLowerCase());
-        const passesFilterList = true;
-        // const passesFilterList =
-        //   !allFilters.length ||
-        //   api.apiVersions.some((apiVersion) => {
-        //     return allFilters.every((filter) => {
-        //       return (
-        //         (filter.type === FilterType.name &&
-        //           api.apiProductDisplayName
-        //             .toLocaleLowerCase()
-        //             .includes(filter.displayName.toLocaleLowerCase())) ||
-        //         (filter.type === FilterType.keyValuePair &&
-        //           apiVersion.customMetadata &&
-        //           apiVersion.customMetadata[
-        //             parsePairString(filter.displayName).pairKey
-        //           ] === parsePairString(filter.displayName).value) ||
-        //         (filter.type === FilterType.apiType && true) // This is the only type available for now
-        //       );
-        //     });
-        //   });
+          app.name.toLocaleLowerCase().includes(nameFilter.toLocaleLowerCase());
+        const passesFilterList = allFilters.every((filter) => {
+          return (
+            filter.type === FilterType.name &&
+            app.name
+              .toLocaleLowerCase()
+              .includes(filter.displayName.toLocaleLowerCase())
+            // ||
+            // (filter.type === FilterType.keyValuePair &&
+            //   apiVersion.customMetadata &&
+            //   apiVersion.customMetadata[
+            //     parsePairString(filter.displayName).pairKey
+            //   ] === parsePairString(filter.displayName).value) ||
+            // (filter.type === FilterType.apiType && true) // This is the only type available for now
+          );
+        });
         return passesNameFilter && passesFilterList;
       })
       .sort((a, b) => a.name.localeCompare(b.name));

--- a/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { di } from "react-magnetic-di";
+import { useListApps } from "../../../Apis/hooks";
+import { FilterPair } from "../../../Utility/filter-utility";
+import { EmptyData } from "../../Common/EmptyData";
+import { Loading } from "../../Common/Loading";
+import { AppsPageStyles } from "../AppsPage.style";
+import { AppSummaryGridCard } from "./AppSummaryCards/AppSummaryGridCard";
+import { AppSummaryListCard } from "./AppSummaryCards/AppSummaryListCard";
+
+export function AppsList({
+  allFilters,
+  nameFilter,
+  usingGridView,
+}: {
+  allFilters: FilterPair[];
+  nameFilter: string;
+  usingGridView: boolean;
+}) {
+  di(useListApps);
+  const { isLoading, data: appsList } = useListApps("123");
+
+  //
+  // Filter the list of apps.
+  //
+  const filteredAppsList = useMemo(() => {
+    if (!appsList?.length) {
+      return [];
+    }
+    return appsList
+      .filter((api) => {
+        let passesNameFilter =
+          !nameFilter ||
+          api.name.toLocaleLowerCase().includes(nameFilter.toLocaleLowerCase());
+        const passesFilterList = true;
+        // const passesFilterList =
+        //   !allFilters.length ||
+        //   api.apiVersions.some((apiVersion) => {
+        //     return allFilters.every((filter) => {
+        //       return (
+        //         (filter.type === FilterType.name &&
+        //           api.apiProductDisplayName
+        //             .toLocaleLowerCase()
+        //             .includes(filter.displayName.toLocaleLowerCase())) ||
+        //         (filter.type === FilterType.keyValuePair &&
+        //           apiVersion.customMetadata &&
+        //           apiVersion.customMetadata[
+        //             parsePairString(filter.displayName).pairKey
+        //           ] === parsePairString(filter.displayName).value) ||
+        //         (filter.type === FilterType.apiType && true) // This is the only type available for now
+        //       );
+        //     });
+        //   });
+        return passesNameFilter && passesFilterList;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [appsList, allFilters, nameFilter]);
+
+  //
+  // Render
+  //
+  if (isLoading) {
+    return <Loading message="Getting list of apps..." />;
+  }
+  if (!filteredAppsList.length) {
+    return <EmptyData topic="app" />;
+  }
+  if (usingGridView) {
+    return (
+      <AppsPageStyles.AppGridList>
+        {filteredAppsList.map((api) => (
+          <AppSummaryGridCard app={api} key={api.id} />
+        ))}
+      </AppsPageStyles.AppGridList>
+    );
+  }
+  return (
+    <div>
+      {filteredAppsList.map((app) => (
+        <AppSummaryListCard app={app} key={app.id} />
+      ))}
+    </div>
+  );
+}

--- a/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
@@ -18,7 +18,9 @@ export function AppsList({
   usingGridView: boolean;
 }) {
   di(useListApps);
-  const { isLoading, data: appsList } = useListApps("123");
+  const { isLoading, data: appsList } = useListApps(
+    "8e543407-cfdb-4061-b3ac-841faa715edf"
+  );
 
   //
   // Filter the list of apps.

--- a/projects/ui/src/Components/Apps/PageContent/AppsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsPageContent.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { FilterPair } from "../../../Utility/filter-utility";
 import { ErrorBoundary } from "../../Common/ErrorBoundary";
-import { ApisFilter } from "./ApisFilter";
-import { ApisList } from "./ApisList";
+import { AppsFilter } from "./AppsFilter";
+import { AppsList } from "./AppsList";
 
-export function ApisTabContent() {
+export function AppsPageContent() {
   const [allFilters, setAllFilters] = useState<FilterPair[]>([]);
   const [nameFilter, setNameFilter] = useState<string>("");
 
@@ -21,9 +21,9 @@ export function ApisTabContent() {
 
   return (
     <div>
-      <ApisFilter filters={filters} />
+      <AppsFilter filters={filters} />
       <ErrorBoundary fallback="There was an issue loading the list of APIs">
-        <ApisList
+        <AppsList
           allFilters={allFilters}
           nameFilter={nameFilter}
           usingGridView={usingGridView}

--- a/projects/ui/src/Components/Common/Banner/BannerHeadingTitle.tsx
+++ b/projects/ui/src/Components/Common/Banner/BannerHeadingTitle.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import { svgColorReplace } from "../../../Styles/utils";
 
 const BannerHeadingTitleContainer = styled.div(
   ({ theme }) => css`
@@ -24,6 +25,7 @@ const BannerHeadingTitleContainer = styled.div(
       width: 46px;
       height: 46px;
     }
+    ${svgColorReplace(theme.defaultColoredText)}
   `
 );
 

--- a/projects/ui/src/Components/Common/EmptyData.tsx
+++ b/projects/ui/src/Components/Common/EmptyData.tsx
@@ -7,6 +7,7 @@ const LoadingContainer = styled.div(
     flex-direction: column;
     align-items: center;
     width: 100%;
+    padding-bottom: 30px;
 
     // A pretty spinner while they wait...
     // .inner and .outer define the two circling balls, and

--- a/projects/ui/src/Components/Common/Loading.tsx
+++ b/projects/ui/src/Components/Common/Loading.tsx
@@ -1,11 +1,17 @@
 import { Box, Flex, Loader, Text } from "@mantine/core";
 import { colors } from "../../Styles";
 
-export function Loading({ message }: { message?: string }) {
+export function Loading({
+  message,
+  small,
+}: {
+  message?: string;
+  small?: boolean;
+}) {
   return (
-    <Box p={"10px"}>
+    <Box p={small ? "5px" : "10px"}>
       <Flex align="center" justify="center" direction="column" gap="20px">
-        <Loader size={"50px"} color={colors.seaBlue} />
+        <Loader size={small ? "20px" : "50px"} color={colors.seaBlue} />
         {!!message && <Text color={colors.augustGrey}>{message}</Text>}
       </Flex>
     </Box>

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -155,11 +155,24 @@ export function Header() {
   const routerLocation = useLocation();
   const { isLoggedIn } = useContext(PortalAuthContext);
 
-  const inAPIsArea = useMemo(() => {
-    return ["/apis", "/api-details/"].some((s) =>
-      routerLocation.pathname.includes(s)
-    );
-  }, [routerLocation.pathname]);
+  const inArea = (paths: string[]) => {
+    return paths.some((s) => routerLocation.pathname.includes(s));
+  };
+
+  const inAPIsArea = useMemo(
+    () => inArea(["/apis", "/api-details/"]),
+    [routerLocation.pathname]
+  );
+
+  const inAppsArea = useMemo(
+    () => inArea(["/apps", "/app-details/"]),
+    [routerLocation.pathname]
+  );
+
+  const inTeamsArea = useMemo(
+    () => inArea(["/teams", "/team-details/"]),
+    [routerLocation.pathname]
+  );
 
   const { pageContentIsWide } = useContext(AppContext);
 
@@ -181,6 +194,22 @@ export function Header() {
               className={`navLink ${inAPIsArea ? "active" : ""}`}
             >
               APIs
+            </NavLink>
+            {/* 
+
+            // TODO: Check which routes here require auth. 
+            */}
+            <NavLink
+              to={"/apps"}
+              className={`navLink ${inAppsArea ? "active" : ""}`}
+            >
+              Apps
+            </NavLink>
+            <NavLink
+              to={"/teams"}
+              className={`navLink ${inTeamsArea ? "active" : ""}`}
+            >
+              Teams
             </NavLink>
             <div className="divider" />
             <ErrorBoundary fallback="Access issues" class="horizontalError">

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -24,7 +24,7 @@ export function TeamSummaryGridCard({ team }: { team: Team }) {
   );
 
   return (
-    <GridCardStyles.GridCard to={getTeamDetailsLink(team)}>
+    <GridCardStyles.GridCardWithLink to={getTeamDetailsLink(team)}>
       <div className="content">
         <div className="apiImageHolder">
           <img src={defaultCardImage} alt="" role="banner" />
@@ -46,6 +46,6 @@ export function TeamSummaryGridCard({ team }: { team: Team }) {
           <Icon.TeamsIcon />
         </div>
       </div>
-    </GridCardStyles.GridCard>
+    </GridCardStyles.GridCardWithLink>
   );
 }

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -1,14 +1,20 @@
+import { Box, Flex } from "@mantine/core";
 import { useMemo } from "react";
+import { di } from "react-magnetic-di";
 import { NavLink } from "react-router-dom";
 import { Team } from "../../../../Apis/api-types";
+import { useListApps, useListMembers } from "../../../../Apis/hooks";
 import { Icon } from "../../../../Assets/Icons";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { getTeamDetailsLink } from "../../../../Utility/link-builders";
+import { SubscriptionInfoCardStyles } from "../../../Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style";
+import { Loading } from "../../../Common/Loading";
 
 /**
  * MAIN COMPONENT
  **/
 export function TeamSummaryGridCard({ team }: { team: Team }) {
+  di(useListApps, useListMembers);
   // In the future banner images may come through API data.
   //   Even when that is the case, a default image may be desired
   //   for when no image is available.
@@ -23,29 +29,52 @@ export function TeamSummaryGridCard({ team }: { team: Team }) {
     [team.id]
   );
 
+  const { isLoading: isLoadingApps, data: teamApps } = useListApps(team.id);
+  const { isLoading: isLoadingMembers, data: teamMembers } = useListMembers(
+    team.id
+  );
+
   return (
-    <GridCardStyles.GridCardWithLink to={getTeamDetailsLink(team)}>
+    <GridCardStyles.GridCard whiteBg>
       <div className="content">
-        <div className="apiImageHolder">
-          <img src={defaultCardImage} alt="" role="banner" />
-        </div>
-        <div className="details">
-          <div>
-            <h4 className="title">{team.name}</h4>
-          </div>
-        </div>
+        <Box p={"20px"}>
+          <Flex direction={"column"} align={"flex-start"} gap={"5px"}>
+            <SubscriptionInfoCardStyles.CardTitleSmall>
+              {team.name}
+            </SubscriptionInfoCardStyles.CardTitleSmall>
+            <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
+              <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
+                <Icon.AppIcon width={20} />
+                {isLoadingApps ? (
+                  <Loading small />
+                ) : (
+                  <SubscriptionInfoCardStyles.Text>
+                    {teamApps?.length} App{teamApps?.length === 1 ? "" : "s"}
+                  </SubscriptionInfoCardStyles.Text>
+                )}
+              </Flex>
+              |
+              <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
+                <Icon.UserIcon width={20} />
+                {isLoadingMembers ? (
+                  <Loading small />
+                ) : (
+                  <SubscriptionInfoCardStyles.Text>
+                    {teamMembers?.length} Member
+                    {teamMembers?.length === 1 ? "" : "s"}
+                  </SubscriptionInfoCardStyles.Text>
+                )}
+              </Flex>
+            </Flex>
+            <GridCardStyles.Description>
+              {team.description}
+            </GridCardStyles.Description>
+          </Flex>
+        </Box>
       </div>
-      <div className="footer">
-        <div className="metaInfo">
-          <Icon.SmallCodeGear />
-          <div className="typeTitle">
-            <NavLink to={getTeamDetailsLink(team)}>MANAGE</NavLink>
-          </div>
-        </div>
-        <div className="typeIcon">
-          <Icon.TeamsIcon />
-        </div>
-      </div>
-    </GridCardStyles.GridCardWithLink>
+      <SubscriptionInfoCardStyles.Footer>
+        <NavLink to={getTeamDetailsLink(team)}>MANAGE</NavLink>
+      </SubscriptionInfoCardStyles.Footer>
+    </GridCardStyles.GridCard>
   );
 }

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from "react";
+import { NavLink } from "react-router-dom";
+import { Team } from "../../../../Apis/api-types";
+import { Icon } from "../../../../Assets/Icons";
+import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
+import { getTeamDetailsLink } from "../../../../Utility/link-builders";
+
+/**
+ * MAIN COMPONENT
+ **/
+export function TeamSummaryGridCard({ team }: { team: Team }) {
+  // In the future banner images may come through API data.
+  //   Even when that is the case, a default image may be desired
+  //   for when no image is available.
+  // Further, you may have some clever trick for setting one of
+  //   many default images.
+  const defaultCardImage = useMemo(
+    () => {
+      return "https://img.huffingtonpost.com/asset/57f2730f170000f70aac9059.jpeg?ops=scalefit_960_noupscale";
+    },
+    // Currently we don't need to change images unless the api itself has changed.
+    //   Depending on the function within the memo, this may not always be the case.
+    [team.id]
+  );
+
+  return (
+    <GridCardStyles.GridCard to={getTeamDetailsLink(team)}>
+      <div className="content">
+        <div className="apiImageHolder">
+          <img src={defaultCardImage} alt="" role="banner" />
+        </div>
+        <div className="details">
+          <div>
+            <h4 className="title">{team.name}</h4>
+          </div>
+        </div>
+      </div>
+      <div className="footer">
+        <div className="metaInfo">
+          <Icon.SmallCodeGear />
+          <div className="typeTitle">
+            <NavLink to={getTeamDetailsLink(team)}>MANAGE</NavLink>
+          </div>
+        </div>
+        <div className="typeIcon">
+          <Icon.TeamsIcon />
+        </div>
+      </div>
+    </GridCardStyles.GridCard>
+  );
+}

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -1,5 +1,4 @@
 import { Box, Flex } from "@mantine/core";
-import { useMemo } from "react";
 import { di } from "react-magnetic-di";
 import { NavLink } from "react-router-dom";
 import { Team } from "../../../../Apis/api-types";
@@ -15,19 +14,6 @@ import { Loading } from "../../../Common/Loading";
  **/
 export function TeamSummaryGridCard({ team }: { team: Team }) {
   di(useListApps, useListMembers);
-  // In the future banner images may come through API data.
-  //   Even when that is the case, a default image may be desired
-  //   for when no image is available.
-  // Further, you may have some clever trick for setting one of
-  //   many default images.
-  const defaultCardImage = useMemo(
-    () => {
-      return "https://img.huffingtonpost.com/asset/57f2730f170000f70aac9059.jpeg?ops=scalefit_960_noupscale";
-    },
-    // Currently we don't need to change images unless the api itself has changed.
-    //   Depending on the function within the memo, this may not always be the case.
-    [team.id]
-  );
 
   const { isLoading: isLoadingApps, data: teamApps } = useListApps(team.id);
   const { isLoading: isLoadingMembers, data: teamMembers } = useListMembers(

--- a/projects/ui/src/Components/Teams/PageContent/TeamsList.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamsList.tsx
@@ -1,0 +1,28 @@
+import { di } from "react-magnetic-di";
+import { useListTeams } from "../../../Apis/hooks";
+import { EmptyData } from "../../Common/EmptyData";
+import { Loading } from "../../Common/Loading";
+import { TeamsPageStyles } from "../TeamsPage.style";
+import { TeamSummaryGridCard } from "./TeamSummaryCards/TeamSummaryGridCard";
+
+export function TeamsList() {
+  di(useListTeams);
+  const { isLoading, data: teamsList } = useListTeams();
+
+  //
+  // Render
+  //
+  if (isLoading) {
+    return <Loading message="Getting list of teams..." />;
+  }
+  if (!teamsList?.length) {
+    return <EmptyData topic="team" />;
+  }
+  return (
+    <TeamsPageStyles.TeamGridList>
+      {teamsList.map((team) => (
+        <TeamSummaryGridCard team={team} key={team.id} />
+      ))}
+    </TeamsPageStyles.TeamGridList>
+  );
+}

--- a/projects/ui/src/Components/Teams/TeamsPage.style.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.style.tsx
@@ -5,5 +5,6 @@ export namespace TeamsPageStyles {
     display: grid;
     grid-gap: 30px;
     grid-template-columns: 1fr 1fr 1fr;
+    margin-bottom: 30px;
   `;
 }

--- a/projects/ui/src/Components/Teams/TeamsPage.style.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.style.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export namespace TeamsPageStyles {
+  export const TeamGridList = styled.div`
+    display: grid;
+    grid-gap: 30px;
+    grid-template-columns: 1fr 1fr 1fr;
+  `;
+}

--- a/projects/ui/src/Components/Teams/TeamsPage.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.tsx
@@ -1,0 +1,19 @@
+import { Icon } from "../../Assets/Icons";
+import { BannerHeading } from "../Common/Banner/BannerHeading";
+import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
+import { PageContainer } from "../Common/PageContainer";
+import { TeamsList } from "./PageContent/TeamsList";
+
+export function TeamsPage() {
+  return (
+    <PageContainer>
+      <BannerHeading
+        title={<BannerHeadingTitle text={"Teams"} logo={<Icon.TeamsIcon />} />}
+        description={"Browse the list of Teams in this portal."}
+        breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Teams" }]}
+      />
+
+      <TeamsList />
+    </PageContainer>
+  );
+}

--- a/projects/ui/src/Styles/shared/Filters.style.tsx
+++ b/projects/ui/src/Styles/shared/Filters.style.tsx
@@ -1,6 +1,7 @@
 import { Theme, css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { borderRadiusConstants } from "../../../Styles/constants";
+import { PrimaryTrimmedSmallWhiteContainer } from "../PrimaryTrimmedSmallWhiteContainer";
+import { borderRadiusConstants } from "../constants";
 
 const makeFilterPlaceholderTextsCSS = (theme: Theme) => css`
   color: ${theme.augustGrey};
@@ -37,7 +38,7 @@ const makeFilterBoxCSS = (theme: Theme) => css`
   background: white;
 `;
 
-export namespace ApisFilterStyles {
+export namespace FilterStyles {
   export const FilterArea = styled.div(
     ({ theme }) => css`
       margin-bottom: 30px;
@@ -214,6 +215,83 @@ export namespace ApisFilterStyles {
         padding: 8px 15px 0 25px;
         border-radius: ${`0 0 ${borderRadiusConstants.small} ${borderRadiusConstants.small}`};
         background: ${theme.splashBlue};
+      }
+    `
+  );
+
+  export const ActiveFiltersGrid = styled.div`
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+  `;
+
+  export const ActiveFilter = styled(PrimaryTrimmedSmallWhiteContainer)(
+    ({ theme }) => css`
+      display: inline-flex;
+      align-items: center;
+      font-size: 12px;
+      line-height: 22px;
+      height: 22px;
+      margin: 0 8px 8px 0;
+      font-size: 13px;
+      padding-right: 2px;
+
+      button.closingX {
+        margin-left: 5px;
+        border-radius: 50%;
+        padding: 5px;
+        svg {
+          width: 8px;
+          height: 8px;
+          margin-left: 0px !important;
+          * {
+            stroke: ${theme.primary};
+          }
+        }
+        &:hover {
+          background: ${theme.splashBlueLight7};
+          svg * {
+            fill: white;
+          }
+        }
+        &:active {
+          background: ${theme.splashBlue};
+        }
+      }
+    `
+  );
+
+  export const ClearAllButton = styled.button(
+    ({ theme }) => css`
+      border: 1px solid ${theme.primary};
+      color: ${theme.primary};
+      background-color: ${theme.background};
+      display: inline-block;
+      padding: 0 10px;
+      border-radius: ${borderRadiusConstants.standard};
+
+      display: inline-flex;
+      align-items: center;
+      font-size: 12px;
+      line-height: 22px;
+      height: 22px;
+      margin: 0 8px 8px 0;
+      font-size: 13px;
+
+      background: ${theme.primary};
+      color: white;
+      margin: 0;
+
+      svg {
+        stroke: white;
+      }
+      &:hover {
+        border-color: ${theme.primaryLight10};
+        background: ${theme.primaryLight10};
+      }
+      &:active {
+        border-color: ${theme.primaryLight20};
+        background: ${theme.primaryLight20};
       }
     `
   );

--- a/projects/ui/src/Styles/shared/GridCard.style.tsx
+++ b/projects/ui/src/Styles/shared/GridCard.style.tsx
@@ -5,17 +5,27 @@ import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../PrimaryTrimmedSmall
 import { borderRadiusConstants } from "../constants";
 
 export namespace GridCardStyles {
-  export const GridCard = styled.div(
+  export const Description = styled.div(
     ({ theme }) => css`
+      text-align: left;
+      color: ${theme.septemberGrey};
+      font-size: 0.95rem;
+    `
+  );
+
+  export const GridCard = styled.div<{ whiteBg?: boolean }>(
+    ({ theme, whiteBg }) => css`
       display: flex;
       flex-direction: column;
 
       height: 100%;
-      min-height: 260px;
+      /* min-height: 260px; */
+      min-height: 100px;
       border-radius: ${borderRadiusConstants.small};
+      box-shadow: 1px 1px 5px ${theme.splashBlue};
 
       border: 1px solid ${theme.splashBlue};
-      background: ${theme.lightGreyTransparent};
+      background: ${whiteBg ? "white" : theme.lightGreyTransparent};
       color: ${theme.defaultColoredText};
       text-align: center;
 

--- a/projects/ui/src/Styles/shared/GridCard.style.tsx
+++ b/projects/ui/src/Styles/shared/GridCard.style.tsx
@@ -1,11 +1,11 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { NavLink } from "react-router-dom";
-import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../../../../Styles/PrimaryTrimmedSmallWhiteContainer";
-import { borderRadiusConstants } from "../../../../Styles/constants";
+import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../PrimaryTrimmedSmallWhiteContainer";
+import { borderRadiusConstants } from "../constants";
 
-export namespace ApiSummaryGridCardStyles {
-  export const ApiGridCardWithLink = styled(NavLink)(
+export namespace GridCardStyles {
+  export const GridCard = styled(NavLink)(
     ({ theme }) => css`
       display: flex;
       flex-direction: column;
@@ -113,4 +113,6 @@ export namespace ApiSummaryGridCardStyles {
       }
     `
   );
+
+  export const GridCardWithLink = styled(GridCard)().withComponent(NavLink);
 }

--- a/projects/ui/src/Styles/shared/GridCard.style.tsx
+++ b/projects/ui/src/Styles/shared/GridCard.style.tsx
@@ -5,7 +5,7 @@ import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../PrimaryTrimmedSmall
 import { borderRadiusConstants } from "../constants";
 
 export namespace GridCardStyles {
-  export const GridCard = styled(NavLink)(
+  export const GridCard = styled.div(
     ({ theme }) => css`
       display: flex;
       flex-direction: column;
@@ -97,7 +97,11 @@ export namespace GridCardStyles {
           }
         }
       }
+    `
+  );
 
+  export const GridCardWithLink = styled(GridCard)(
+    ({ theme }) => css`
       //
       // Shared styles between API summary cards
       //
@@ -112,7 +116,5 @@ export namespace GridCardStyles {
         box-shadow: 0 0 5px ${theme.pondBlue};
       }
     `
-  );
-
-  export const GridCardWithLink = styled(GridCard)().withComponent(NavLink);
+  ).withComponent(NavLink);
 }

--- a/projects/ui/src/Styles/shared/ListCard.style.tsx
+++ b/projects/ui/src/Styles/shared/ListCard.style.tsx
@@ -1,10 +1,10 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../../../../Styles/PrimaryTrimmedSmallWhiteContainer";
-import { borderRadiusConstants } from "../../../../Styles/constants";
+import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../PrimaryTrimmedSmallWhiteContainer";
+import { borderRadiusConstants } from "../constants";
 
-export namespace ApiSummaryListCardStyles {
-  export const ApiListCardWithLink = styled.div(
+export namespace ListCardStyles {
+  export const ListCardWithLink = styled.div(
     ({ theme }) => css`
       margin-bottom: 30px;
       border-radius: ${borderRadiusConstants.small};

--- a/projects/ui/src/Styles/utils.ts
+++ b/projects/ui/src/Styles/utils.ts
@@ -1,9 +1,5 @@
 import { css } from "@emotion/react";
 
-// export function cssProp(prop: string, value: string | number | undefined) {
-//   return value !== undefined ? `${prop}:${value};` : "";
-// }
-
 // HEX isn't made more specific as after a point it becomes "to complex" for the IDE to handle
 type HEX = `#${string}`;
 export type Color = HEX;
@@ -13,44 +9,6 @@ export type ColorOrAllowed =
   | "transparent"
   | "white"
   | "black";
-// export type ColorThemeFunc = (theme: Theme) => ColorOrAllowed;
-
-// /**
-//  * Adds hex to the end of a hex color
-//  * @param hex
-//  * @param alpha 0-1
-//  */
-// export function hexAddAlpha(hex: HEX, alpha: number): HEX {
-//   const hexAlpha = (Math.floor(255 * alpha) % 256)
-//     .toString(16)
-//     .padStart(2, "0");
-//   return (hex + hexAlpha) as HEX;
-// }
-
-// export function handleColorOrColorThemeFunc(
-//   color: ColorOrAllowed | ColorThemeFunc | undefined,
-//   tm: Theme
-// ): ColorOrAllowed | undefined {
-//   return typeof color === "function" ? color(tm) : color;
-// }
-
-// export function svgBasics(
-//   size?:
-//     | number
-//     | string
-//     | { width?: number | string; height?: number | string },
-//   color?: ColorOrAllowed
-// ) {
-//   const width = typeof size !== "object" ? size : size?.width;
-//   const height = typeof size !== "object" ? size : size?.height;
-//   return css`
-//     svg {
-//       ${cssProp("width", typeof width === "number" ? `${width}px` : width)}
-//       ${cssProp("height", typeof height === "number" ? `${height}px` : height)}
-//     }
-//     ${color !== undefined && svgColorReplace(color)}
-//   `;
-// }
 
 /**
  * An SVG color replace function that works on both stroke and fill automatically.

--- a/projects/ui/src/Styles/utils.ts
+++ b/projects/ui/src/Styles/utils.ts
@@ -1,0 +1,88 @@
+import { css } from "@emotion/react";
+
+// export function cssProp(prop: string, value: string | number | undefined) {
+//   return value !== undefined ? `${prop}:${value};` : "";
+// }
+
+// HEX isn't made more specific as after a point it becomes "to complex" for the IDE to handle
+type HEX = `#${string}`;
+export type Color = HEX;
+export type ColorOrAllowed =
+  | Color
+  | "currentColor"
+  | "transparent"
+  | "white"
+  | "black";
+// export type ColorThemeFunc = (theme: Theme) => ColorOrAllowed;
+
+// /**
+//  * Adds hex to the end of a hex color
+//  * @param hex
+//  * @param alpha 0-1
+//  */
+// export function hexAddAlpha(hex: HEX, alpha: number): HEX {
+//   const hexAlpha = (Math.floor(255 * alpha) % 256)
+//     .toString(16)
+//     .padStart(2, "0");
+//   return (hex + hexAlpha) as HEX;
+// }
+
+// export function handleColorOrColorThemeFunc(
+//   color: ColorOrAllowed | ColorThemeFunc | undefined,
+//   tm: Theme
+// ): ColorOrAllowed | undefined {
+//   return typeof color === "function" ? color(tm) : color;
+// }
+
+// export function svgBasics(
+//   size?:
+//     | number
+//     | string
+//     | { width?: number | string; height?: number | string },
+//   color?: ColorOrAllowed
+// ) {
+//   const width = typeof size !== "object" ? size : size?.width;
+//   const height = typeof size !== "object" ? size : size?.height;
+//   return css`
+//     svg {
+//       ${cssProp("width", typeof width === "number" ? `${width}px` : width)}
+//       ${cssProp("height", typeof height === "number" ? `${height}px` : height)}
+//     }
+//     ${color !== undefined && svgColorReplace(color)}
+//   `;
+// }
+
+/**
+ * An SVG color replace function that works on both stroke and fill automatically.
+ *
+ * WARNING: This does not work properly on colors applied via inline <defs><style>.
+ * - Since there is no attribute to detect, this can't overwrite it. This isn't an issue when the style is fill:none (since we don't want to overwrite that anyways)
+ * - One solution is to move the styles out of a class and onto the element directly (or on a <g> surrounding the elements)
+ * - Otherwise the following classes may be applied on an element to force the issue: `skip-fill-replace`, `fill-replace`, `skip-stroke-replace`, `stroke-replace`
+ * @param color The color to replace with
+ */
+export function svgColorReplace(color?: ColorOrAllowed) {
+  if (color === undefined) return;
+  return css`
+    svg {
+      // By default all svg elements have a fill color that inherits from svg's fill (black if undefined); change this default to our color
+      fill: ${color};
+
+      // If a fill is defined (but not set to none as a way to hide it), then replace that color
+      *[fill]:not([fill="none"], [fill="transparent"], .skip-fill-replace),
+      .fill-replace {
+        fill: ${color};
+      }
+
+      // replace stroke if it exists - since stroke is none by default there shouldn't be a reason to check it, but do so for safety
+      *[stroke]:not(
+          [stroke="none"],
+          [stroke="transparent"],
+          .skip-stroke-replace
+        ),
+      .stroke-replace {
+        stroke: ${color};
+      }
+    }
+  `;
+}

--- a/projects/ui/src/Utility/filter-utility.ts
+++ b/projects/ui/src/Utility/filter-utility.ts
@@ -1,0 +1,25 @@
+import { KeyValuePair } from "../Components/Common/DataPairPill";
+
+/**
+ * HELPER TYPE DEFS
+ **/
+export enum FilterType {
+  name,
+  keyValuePair,
+  apiType,
+}
+export type FilterPair = { displayName: string; type: FilterType };
+
+/**
+ * HELPER FUNCTION
+ **/
+export function getPairString(pair: KeyValuePair) {
+  return `${pair.pairKey} : ${pair.value}`;
+}
+export function parsePairString(pairString: string): KeyValuePair {
+  const [pairKey, value] = pairString.split(":").map((s) => s.trim());
+  return {
+    pairKey,
+    value,
+  };
+}

--- a/projects/ui/src/Utility/link-builders.ts
+++ b/projects/ui/src/Utility/link-builders.ts
@@ -1,4 +1,4 @@
-import { APIVersion } from "../../Apis/api-types";
+import { APIVersion, App, Team } from "../Apis/api-types";
 
 export function getApiDetailsLink<
   T extends { apiProductId: string; apiVersions: APIVersion[] }
@@ -6,4 +6,12 @@ export function getApiDetailsLink<
   return `/api-details/${api.apiProductId}/${
     api.apiVersions.length > 0 ? api.apiVersions.at(0)?.apiVersion : ""
   }`;
+}
+
+export function getAppDetailsLink(app: App) {
+  return `/app-details/${app.id}`;
+}
+
+export function getTeamDetailsLink(team: Team) {
+  return `/team-details/${team.id}`;
 }


### PR DESCRIPTION
This PR begins to add the apps and teams pages. There is some coupling between these pages, so they needed to be added together. But to prevent this PR from getting too large, this just addresses the initial scaffolding, and the rest will be addressed in a follow-up PR.

This is now being tested with real data 🎉 . Let me know if you want help setting this up locally.


<img width="1479" alt="Screenshot 2024-03-04 at 3 03 17 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/174c4b7a-8202-4534-83d6-546f8dd94d27">

<img width="1286" alt="Screenshot 2024-03-04 at 3 11 17 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/228a3629-b1b2-4a08-9068-2e4b295bdc42">

<img width="1479" alt="Screenshot 2024-03-04 at 3 03 38 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/4673986c-6918-4cf9-8de2-e3d369eb5c7d">

