### PR TITLE
Adding the rest of the apps and teams pages

### DIFF
--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -82,7 +82,7 @@ const useSwrWithAuth = <T>(
 
 /**
  *  This is the same as useSwrWithAuth, but works for an array of paths.
- * e.g.`["/apps/team-id-1/", "/apps/team-id-2", ...]` will return:
+ * e.g.`["/teams/team-id-1/apps", "/teams/team-id-2/apps", ...]` will return:
  * `[getAppsReponseForTeam1, getAppsResponseForTeam2, ...]`
  *
  * The return values must be of the same type.

--- a/projects/ui/src/Components/Apis/ApisTab/ApisFilter.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApisFilter.tsx
@@ -1,6 +1,7 @@
 import { Select, TextInput } from "@mantine/core";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { Icon } from "../../../Assets/Icons";
+import { AppContext } from "../../../Context/AppContext";
 import { FilterStyles as Styles } from "../../../Styles/shared/Filters.style";
 import {
   FilterPair,
@@ -14,15 +15,15 @@ import GridListToggle from "../../Common/GridListToggle";
  * MAIN COMPONENT
  **/
 type ApisFiltrationProp = {
-  showingGrid: boolean;
   allFilters: FilterPair[];
   setAllFilters: (newFiltersList: FilterPair[]) => void;
-  setShowingGrid: (showGrid: boolean) => void;
   nameFilter: string;
   setNameFilter: (newNamesList: string) => void;
 };
 
 export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
+  const { preferGridView, setPreferGridView } = useContext(AppContext);
+
   const [pairFilter, setPairFilter] = useState<KeyValuePair>({
     pairKey: "",
     value: "",
@@ -179,8 +180,8 @@ export function ApisFilter({ filters }: { filters: ApisFiltrationProp }) {
           />
         </div>
         <GridListToggle
-          onChange={(newIsList) => filters.setShowingGrid(!newIsList)}
-          isList={!filters.showingGrid}
+          onChange={(newIsList) => setPreferGridView(!newIsList)}
+          isList={!preferGridView}
         />
       </div>
 

--- a/projects/ui/src/Components/Apis/ApisTab/ApisFilter.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApisFilter.tsx
@@ -11,9 +11,6 @@ import {
 import { KeyValuePair } from "../../Common/DataPairPill";
 import GridListToggle from "../../Common/GridListToggle";
 
-/**
- * MAIN COMPONENT
- **/
 type ApisFiltrationProp = {
   allFilters: FilterPair[];
   setAllFilters: (newFiltersList: FilterPair[]) => void;

--- a/projects/ui/src/Components/Apis/ApisTab/ApisList.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApisList.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { di } from "react-magnetic-di";
 import { useListApis } from "../../../Apis/hooks";
+import { AppContext } from "../../../Context/AppContext";
 import {
   FilterPair,
   FilterType,
@@ -15,13 +16,12 @@ import { ApiSummaryListCard } from "./ApiSummaryCards/ApiSummaryListCard";
 export function ApisList({
   allFilters,
   nameFilter,
-  usingGridView,
 }: {
   allFilters: FilterPair[];
   nameFilter: string;
-  usingGridView: boolean;
 }) {
   di(useListApis);
+  const { preferGridView } = useContext(AppContext);
   const { isLoading, data: apisList } = useListApis();
 
   //
@@ -72,7 +72,7 @@ export function ApisList({
   if (!filteredApisList.length) {
     return <EmptyData topic="API" />;
   }
-  if (usingGridView) {
+  if (preferGridView) {
     return (
       <ApisPageStyles.ApiGridList>
         {filteredApisList.map((api) => (

--- a/projects/ui/src/Components/Apis/ApisTab/ApisTabContent.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApisTabContent.tsx
@@ -8,11 +8,7 @@ export function ApisTabContent() {
   const [allFilters, setAllFilters] = useState<FilterPair[]>([]);
   const [nameFilter, setNameFilter] = useState<string>("");
 
-  const [usingGridView, setUsingGridView] = useState(false);
-
   const filters = {
-    showingGrid: usingGridView,
-    setShowingGrid: setUsingGridView,
     allFilters,
     setAllFilters,
     nameFilter,
@@ -23,11 +19,7 @@ export function ApisTabContent() {
     <div>
       <ApisFilter filters={filters} />
       <ErrorBoundary fallback="There was an issue loading the list of APIs">
-        <ApisList
-          allFilters={allFilters}
-          nameFilter={nameFilter}
-          usingGridView={usingGridView}
-        />
+        <ApisList allFilters={allFilters} nameFilter={nameFilter} />
       </ErrorBoundary>
     </div>
   );

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style.tsx
@@ -26,10 +26,6 @@ export namespace SubscriptionInfoCardStyles {
     border-top-left-radius: inherit;
   `;
 
-  export const Text = styled.span`
-    font-size: 0.95rem;
-  `;
-
   export const Footer = styled(Flex)(
     ({ theme }) => css`
       padding: 6px 20px;

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
@@ -4,6 +4,7 @@ import { di } from "react-magnetic-di";
 import { NavLink } from "react-router-dom";
 import { useListApis } from "../../../Apis/hooks";
 import { AppIcon } from "../../../Assets/Icons/Icons";
+import { CardStyles } from "../../../Styles/shared/Card.style";
 import { getApiDetailsLink } from "../../../Utility/link-builders";
 import { Subscription, subscriptionStateMap } from "../ApisPage";
 import { SubscriptionInfoCardStyles as Styles } from "./SubscriptionInfoCard.style";
@@ -33,9 +34,13 @@ const SubscriptionInfoCard = ({
         </Flex>
         <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
           <AppIcon width={20} />
-          <Styles.Text>{subscription.appName}</Styles.Text>
+          <CardStyles.SmallerText>
+            {subscription.appName}
+          </CardStyles.SmallerText>
         </Flex>
-        <Styles.Text>{subscription.usagePlanName}</Styles.Text>
+        <CardStyles.SmallerText>
+          {subscription.usagePlanName}
+        </CardStyles.SmallerText>
       </Styles.Content>
       {subscribedApi && (
         <Styles.Footer>

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -1,19 +1,32 @@
+import { Box } from "@mantine/core";
+import { useState } from "react";
 import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
+import { Button } from "../Common/Button";
 import { PageContainer } from "../Common/PageContainer";
+import CreateNewAppModal from "./Modals/CreateNewAppModal";
 import { AppsPageContent } from "./PageContent/AppsPageContent";
 
 export function AppsPage() {
+  const [modalOpen, setModalOpen] = useState(false);
+
   return (
     <PageContainer>
       <BannerHeading
         title={<BannerHeadingTitle text={"Apps"} logo={<Icon.AppIcon />} />}
-        description={"Browse the list of Apps in this portal."}
+        description={
+          <>
+            Browse the list of Apps in this portal.
+            <Box pt={"20px"}>
+              <Button onClick={() => setModalOpen(true)}>CREATE NEW APP</Button>
+            </Box>
+          </>
+        }
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Apps" }]}
       />
-
       <AppsPageContent />
+      {modalOpen && <CreateNewAppModal onClose={() => setModalOpen(false)} />}
     </PageContainer>
   );
 }

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -26,7 +26,10 @@ export function AppsPage() {
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Apps" }]}
       />
       <AppsPageContent />
-      {modalOpen && <CreateNewAppModal onClose={() => setModalOpen(false)} />}
+      <CreateNewAppModal
+        opened={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
     </PageContainer>
   );
 }

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -1,16 +1,10 @@
-import { di } from "react-magnetic-di";
-import { useListTeams } from "../../Apis/hooks";
 import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
-import { Loading } from "../Common/Loading";
 import { PageContainer } from "../Common/PageContainer";
 import { AppsPageContent } from "./PageContent/AppsPageContent";
 
 export function AppsPage() {
-  di(useListTeams);
-  const { isLoading } = useListTeams();
-
   return (
     <PageContainer>
       <BannerHeading
@@ -19,12 +13,7 @@ export function AppsPage() {
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Apps" }]}
       />
 
-      {isLoading ? (
-        // Make sure the teams are finished loading since they are a dependency.
-        <Loading message="Loading..." />
-      ) : (
-        <AppsPageContent />
-      )}
+      <AppsPageContent />
     </PageContainer>
   );
 }

--- a/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
@@ -1,0 +1,13 @@
+import { Modal } from "../../Common/Modal";
+
+const CreateNewAppModal = ({ onClose }: { onClose: () => void }) => {
+  return (
+    <Modal
+      onClose={onClose}
+      headContent={<div>create new app</div>}
+      bodyContent={<>Okay</>}
+    />
+  );
+};
+
+export default CreateNewAppModal;

--- a/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
@@ -75,6 +75,7 @@ const CreateNewAppModal = ({
             <label htmlFor="app-team-select">Team</label>
             <Select
               id="app-team-select"
+              // This className="" is intentional and removes the antd select dropdown classname.
               className=""
               value={appTeamId}
               onChange={(value) => {

--- a/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
@@ -1,12 +1,137 @@
-import { Modal } from "../../Common/Modal";
+import { CloseButton, Flex, Input, Select } from "@mantine/core";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { di } from "react-magnetic-di";
+import { useCreateAppMutation, useListTeams } from "../../../Apis/hooks";
+import { FormModalStyles } from "../../../Styles/shared/FormModalStyles";
+import { Button } from "../../Common/Button";
+import { Loading } from "../../Common/Loading";
 
-const CreateNewAppModal = ({ onClose }: { onClose: () => void }) => {
+const CreateNewAppModal = ({
+  opened,
+  onClose,
+}: {
+  opened: boolean;
+  onClose: () => void;
+}) => {
+  di(useListTeams, useCreateAppMutation);
+  const [appName, setAppName] = useState("");
+  const [appDescription, setAppDescription] = useState("");
+  const [appTeamId, setTeamId] = useState("");
+
+  const formRef = useRef<HTMLFormElement>(null);
+  const isFormDisabled = !formRef.current?.checkValidity();
+  const resetForm = () => {
+    setTeamId("");
+    setAppName("");
+    setAppDescription("");
+  };
+
+  const { isLoading: isLoadingTeams, data: teams } = useListTeams();
+  const { trigger: createApp } = useCreateAppMutation(appTeamId);
+
+  const onSubmit = async (e?: FormEvent) => {
+    e?.preventDefault();
+    // Do HTML form validation.
+    formRef.current?.reportValidity();
+    if (isFormDisabled) {
+      return;
+    }
+    await toast.promise(
+      createApp({ name: appName, description: appDescription }),
+      {
+        error: "There was an error creating the app.",
+        loading: "Creating the app...",
+        success: "Created the app!",
+      }
+    );
+    onClose();
+  };
+
+  // Reset the form on close.
+  useEffect(() => {
+    if (!opened) resetForm();
+  }, [opened]);
+
   return (
-    <Modal
+    <FormModalStyles.CustomModal
       onClose={onClose}
-      headContent={<div>create new app</div>}
-      bodyContent={<>Okay</>}
-    />
+      opened={opened}
+      size={"800px"}
+    >
+      <FormModalStyles.HeaderContainer>
+        <div>
+          <FormModalStyles.Title>Create a New App</FormModalStyles.Title>
+          <FormModalStyles.Subtitle>Create a new app.</FormModalStyles.Subtitle>
+        </div>
+        <CloseButton title="Close modal" size={"30px"} />
+      </FormModalStyles.HeaderContainer>
+      <FormModalStyles.HorizLine />
+      {isLoadingTeams || teams === undefined ? (
+        <Loading />
+      ) : (
+        <FormModalStyles.BodyContainerForm ref={formRef} onSubmit={onSubmit}>
+          <FormModalStyles.InputContainer>
+            <label htmlFor="app-team-select">Team</label>
+            <Select
+              id="app-team-select"
+              className=""
+              value={appTeamId}
+              onChange={(value) => {
+                setTeamId(value ?? "");
+              }}
+              data={[
+                {
+                  value: "",
+                  label: "Select a Team",
+                  disabled: true,
+                },
+                ...teams.map((t) => ({
+                  value: t.id,
+                  label: t.name,
+                })),
+              ]}
+            />
+          </FormModalStyles.InputContainer>
+          {appTeamId && (
+            <>
+              <FormModalStyles.InputContainer>
+                <label htmlFor="app-name-input">App Name</label>
+                <Input
+                  id="app-name-input"
+                  required
+                  autoComplete="off"
+                  value={appName}
+                  onChange={(e) => setAppName(e.target.value)}
+                />
+              </FormModalStyles.InputContainer>
+              <FormModalStyles.InputContainer>
+                <label htmlFor="app-description-input">App Description</label>
+                <Input
+                  // This could be a Textarea if newlines exist in the description.
+                  // Then we would need to get the text content using a ref
+                  // so that newlines are preserved when saved.
+                  // <Textarea
+                  id="app-description-input"
+                  required
+                  autoComplete="off"
+                  value={appDescription}
+                  onChange={(e) => setAppDescription(e.target.value)}
+                />
+              </FormModalStyles.InputContainer>
+            </>
+          )}
+          <Flex justify={"flex-end"} gap="20px">
+            <Button className="outline" onClick={onClose} type="button">
+              Cancel
+            </Button>
+            <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">
+              Create App
+            </Button>
+          </Flex>
+        </FormModalStyles.BodyContainerForm>
+      )}
+    </FormModalStyles.CustomModal>
   );
 };
 

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -1,13 +1,14 @@
+import { Box } from "@mantine/core";
 import { useMemo } from "react";
-import { App } from "../../../../Apis/api-types";
 import { Icon } from "../../../../Assets/Icons";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { getAppDetailsLink } from "../../../../Utility/link-builders";
+import { AppWithTeam } from "../AppsList";
 
 /**
  * MAIN COMPONENT
  **/
-export function AppSummaryGridCard({ app }: { app: App }) {
+export function AppSummaryGridCard({ app }: { app: AppWithTeam }) {
   // In the future banner images may come through API data.
   //   Even when that is the case, a default image may be desired
   //   for when no image is available.
@@ -28,21 +29,17 @@ export function AppSummaryGridCard({ app }: { app: App }) {
         <div className="apiImageHolder">
           <img src={defaultCardImage} alt="" role="banner" />
         </div>
-        <div className="details">
-          <div>
-            <h4 className="title">{app.name}</h4>
-          </div>
-        </div>
+        <Box px={"20px"}>
+          <GridCardStyles.Title>{app.name}</GridCardStyles.Title>
+          <GridCardStyles.Description>
+            {app.description}
+          </GridCardStyles.Description>
+        </Box>
       </div>
       <div className="footer">
         <div className="metaInfo">
           <Icon.TeamsIcon />
-          <div className="typeTitle" aria-label="API Type">
-            {/* 
-            // TODO: Add in team info from listTeams()
-            */}
-            Team
-          </div>
+          <div className="typeTitle">{app.team.name}</div>
         </div>
       </div>
     </GridCardStyles.GridCardWithLink>

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -1,6 +1,7 @@
 import { Box } from "@mantine/core";
 import { useMemo } from "react";
 import { Icon } from "../../../../Assets/Icons";
+import { CardStyles } from "../../../../Styles/shared/Card.style";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { getAppDetailsLink } from "../../../../Utility/link-builders";
 import { AppWithTeam } from "../AppsList";
@@ -30,10 +31,8 @@ export function AppSummaryGridCard({ app }: { app: AppWithTeam }) {
           <img src={defaultCardImage} alt="" role="banner" />
         </div>
         <Box px={"20px"}>
-          <GridCardStyles.Title>{app.name}</GridCardStyles.Title>
-          <GridCardStyles.Description>
-            {app.description}
-          </GridCardStyles.Description>
+          <CardStyles.Title>{app.name}</CardStyles.Title>
+          <CardStyles.Description>{app.description}</CardStyles.Description>
         </Box>
       </div>
       <div className="footer">

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mantine/core";
 import { NavLink } from "react-router-dom";
 import { Icon } from "../../../../Assets/Icons";
-import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
+import { CardStyles } from "../../../../Styles/shared/Card.style";
 import { ListCardStyles } from "../../../../Styles/shared/ListCard.style";
 import { getAppDetailsLink } from "../../../../Utility/link-builders";
 import { AppWithTeam } from "../AppsList";
@@ -18,19 +18,9 @@ export function AppSummaryListCard({ app }: { app: AppWithTeam }) {
             <Icon.WrenchGear className="colorIt" />
           </div>
           <Box p={"30px"}>
-            <GridCardStyles.Title>{app.name}</GridCardStyles.Title>
-            <GridCardStyles.Description>
-              {app.description}
-            </GridCardStyles.Description>
+            <CardStyles.Title>{app.name}</CardStyles.Title>
+            <CardStyles.Description>{app.description}</CardStyles.Description>
           </Box>
-          {/* <div className="details">
-            <Flex direction={"column"}>
-              <GridCardStyles.Title>{app.name}</GridCardStyles.Title>
-              <GridCardStyles.Description>
-                {app.description}
-              </GridCardStyles.Description>
-            </Flex>
-          </div> */}
         </div>
         <div className="footer">
           <div className="metaInfo">

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
@@ -1,13 +1,15 @@
+import { Box } from "@mantine/core";
 import { NavLink } from "react-router-dom";
-import { App } from "../../../../Apis/api-types";
 import { Icon } from "../../../../Assets/Icons";
+import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { ListCardStyles } from "../../../../Styles/shared/ListCard.style";
 import { getAppDetailsLink } from "../../../../Utility/link-builders";
+import { AppWithTeam } from "../AppsList";
 
 /**
  * MAIN COMPONENT
  **/
-export function AppSummaryListCard({ app }: { app: App }) {
+export function AppSummaryListCard({ app }: { app: AppWithTeam }) {
   return (
     <NavLink to={getAppDetailsLink(app)}>
       <ListCardStyles.ListCardWithLink>
@@ -15,19 +17,25 @@ export function AppSummaryListCard({ app }: { app: App }) {
           <div className="majorIconHolder">
             <Icon.WrenchGear className="colorIt" />
           </div>
-          <div className="details">
-            <div>
-              <h4 className="title">{app.name}</h4>
-            </div>
-          </div>
+          <Box p={"30px"}>
+            <GridCardStyles.Title>{app.name}</GridCardStyles.Title>
+            <GridCardStyles.Description>
+              {app.description}
+            </GridCardStyles.Description>
+          </Box>
+          {/* <div className="details">
+            <Flex direction={"column"}>
+              <GridCardStyles.Title>{app.name}</GridCardStyles.Title>
+              <GridCardStyles.Description>
+                {app.description}
+              </GridCardStyles.Description>
+            </Flex>
+          </div> */}
         </div>
         <div className="footer">
           <div className="metaInfo">
             <Icon.TeamsIcon />
-            {/* 
-            // TODO: Add in team info from listTeams()
-            */}
-            Team: {app.teamId}
+            <div className="typeTitle">{app.team.name}</div>
           </div>
         </div>
       </ListCardStyles.ListCardWithLink>

--- a/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
@@ -1,5 +1,7 @@
 import { TextInput } from "@mantine/core";
+import { useContext } from "react";
 import { Icon } from "../../../Assets/Icons";
+import { AppContext } from "../../../Context/AppContext";
 import { FilterStyles as Styles } from "../../../Styles/shared/Filters.style";
 import { FilterPair, FilterType } from "../../../Utility/filter-utility";
 import GridListToggle from "../../Common/GridListToggle";
@@ -8,15 +10,14 @@ import GridListToggle from "../../Common/GridListToggle";
  * MAIN COMPONENT
  **/
 type AppsFiltrationProp = {
-  showingGrid: boolean;
   allFilters: FilterPair[];
   setAllFilters: (newFiltersList: FilterPair[]) => void;
-  setShowingGrid: (showGrid: boolean) => void;
   nameFilter: string;
   setNameFilter: (newNamesList: string) => void;
 };
 
 export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
+  const { preferGridView, setPreferGridView } = useContext(AppContext);
   // const [pairFilter, setPairFilter] = useState<KeyValuePair>({
   //   pairKey: "",
   //   value: "",
@@ -176,8 +177,8 @@ export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
         </div> */}
 
         <GridListToggle
-          onChange={(newIsList) => filters.setShowingGrid(!newIsList)}
-          isList={!filters.showingGrid}
+          onChange={(newIsList) => setPreferGridView(!newIsList)}
+          isList={!preferGridView}
         />
       </div>
 

--- a/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
@@ -7,9 +7,6 @@ import { FilterStyles as Styles } from "../../../Styles/shared/Filters.style";
 import { FilterPair, FilterType } from "../../../Utility/filter-utility";
 import GridListToggle from "../../Common/GridListToggle";
 
-/**
- * MAIN COMPONENT
- **/
 type AppsFiltrationProp = {
   allFilters: FilterPair[];
   setAllFilters: (newFiltersList: FilterPair[]) => void;
@@ -25,10 +22,6 @@ export function AppsFilter({
   teams: Team[];
 }) {
   const { preferGridView, setPreferGridView } = useContext(AppContext);
-  // const [pairFilter, setPairFilter] = useState<KeyValuePair>({
-  //   pairKey: "",
-  //   value: "",
-  // });
 
   const addNameFilter = (evt: { target: { value: string } }) => {
     const displayName = evt.target.value;
@@ -47,39 +40,6 @@ export function AppsFilter({
     }
     filters.setNameFilter("");
   };
-
-  // const alterPairKey = (evt: React.ChangeEvent<HTMLInputElement>) => {
-  //   const newKey = evt.target.value;
-  //   setPairFilter({
-  //     pairKey: newKey,
-  //     value: pairFilter.value,
-  //   });
-  // };
-  // const alterKeyValuePair = (evt: React.ChangeEvent<HTMLInputElement>) => {
-  //   const newValue = evt.target.value;
-  //   setPairFilter({
-  //     pairKey: pairFilter.pairKey,
-  //     value: newValue,
-  //   });
-  // };
-
-  // const addKeyValuePairFilter = () => {
-  //   const displayName = getPairString(pairFilter);
-  //   if (displayName.trim() === ":") return;
-  //   // Check for duplicate filters.
-  //   const isDuplicateFilter = filters.allFilters.some(
-  //     (f) => f.type === FilterType.keyValuePair && f.displayName === displayName
-  //   );
-  //   if (isDuplicateFilter) {
-  //     return;
-  //   }
-  //   filters.setAllFilters([
-  //     ...filters.allFilters,
-  //     { displayName, type: FilterType.keyValuePair },
-  //   ]);
-
-  //   setPairFilter({ pairKey: "", value: "" });
-  // };
 
   const addTeamFilter = (addedTeam: string) => {
     filters.setAllFilters([
@@ -135,39 +95,6 @@ export function AppsFilter({
           />
           <Icon.MagnifyingGlass style={{ pointerEvents: "none" }} />
         </form>
-        {/*
-        
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            addKeyValuePairFilter();
-          }}
-          className="pairsFilter"
-        >
-          <div className="tagHolder">
-            <Icon.Tag />
-          </div>
-          <div className="pairHolder">
-            <TextInput
-              size="xs"
-              placeholder="Key"
-              onChange={alterPairKey}
-              value={pairFilter.pairKey}
-            />
-            <span>:</span>
-            <TextInput
-              size="xs"
-              placeholder="Value"
-              onChange={alterKeyValuePair}
-              value={pairFilter.value}
-            />
-          </div>
-          <div className="addButtonHolder">
-            <button type="submit" aria-label="Add Pair Filter">
-              <Icon.Add />
-            </button>
-          </div>
-        </form> */}
         <div className="dropdownFilter">
           <div className="gearHolder">
             <Icon.TeamsIcon />

--- a/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsFilter.tsx
@@ -1,5 +1,6 @@
-import { TextInput } from "@mantine/core";
+import { Select, TextInput } from "@mantine/core";
 import { useContext } from "react";
+import { Team } from "../../../Apis/api-types";
 import { Icon } from "../../../Assets/Icons";
 import { AppContext } from "../../../Context/AppContext";
 import { FilterStyles as Styles } from "../../../Styles/shared/Filters.style";
@@ -16,7 +17,13 @@ type AppsFiltrationProp = {
   setNameFilter: (newNamesList: string) => void;
 };
 
-export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
+export function AppsFilter({
+  filters,
+  teams,
+}: {
+  filters: AppsFiltrationProp;
+  teams: Team[];
+}) {
   const { preferGridView, setPreferGridView } = useContext(AppContext);
   // const [pairFilter, setPairFilter] = useState<KeyValuePair>({
   //   pairKey: "",
@@ -74,12 +81,12 @@ export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
   //   setPairFilter({ pairKey: "", value: "" });
   // };
 
-  // const addTypeFilter = (addedType: string) => {
-  //   filters.setAllFilters([
-  //     ...filters.allFilters,
-  //     { displayName: addedType, type: FilterType.apiType },
-  //   ]);
-  // };
+  const addTeamFilter = (addedTeam: string) => {
+    filters.setAllFilters([
+      ...filters.allFilters,
+      { displayName: addedTeam, type: FilterType.team },
+    ]);
+  };
 
   const removeFilter = (filterPair: FilterPair) => {
     filters.setAllFilters(
@@ -95,19 +102,19 @@ export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
     filters.setAllFilters([]);
   };
 
-  // const selectableTypes = [
-  //   {
-  //     label: "OpenAPI",
-  //     value: "OpenAPI",
-  //   },
-  // ].filter(
-  //   (selectableType) =>
-  //     !filters.allFilters.some(
-  //       (filter) =>
-  //         filter.type === FilterType.apiType &&
-  //         filter.displayName === selectableType.value
-  //     )
-  // );
+  const selectableTypes = teams
+    .map((t) => ({
+      label: t.name,
+      value: t.name,
+    }))
+    .filter(
+      (selectableType) =>
+        !filters.allFilters.some(
+          (filter) =>
+            filter.type === FilterType.team &&
+            filter.displayName === selectableType.value
+        )
+    );
 
   return (
     <Styles.FilterArea>
@@ -161,20 +168,20 @@ export function AppsFilter({ filters }: { filters: AppsFiltrationProp }) {
             </button>
           </div>
         </form> */}
-        {/* <div className="dropdownFilter">
+        <div className="dropdownFilter">
           <div className="gearHolder">
-            <Icon.CodeGear />
+            <Icon.TeamsIcon />
           </div>
           <Select
             className="addTypeFilterSelect"
             size="xs"
             disabled={(selectableTypes ?? []).length === 0}
             data={selectableTypes}
-            onChange={addTypeFilter}
+            onChange={addTeamFilter}
             value=""
-            placeholder="API Type"
+            placeholder="Team"
           />
-        </div> */}
+        </div>
 
         <GridListToggle
           onChange={(newIsList) => setPreferGridView(!newIsList)}

--- a/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
@@ -62,13 +62,15 @@ export function AppsList({
             .includes(nameFilter.toLocaleLowerCase());
         const passesFilterList = allFilters.every((filter) => {
           return (
-            filter.type === FilterType.name &&
-            (app.name
-              .toLocaleLowerCase()
-              .includes(filter.displayName.toLocaleLowerCase()) ||
-              app.team.name
+            (filter.type === FilterType.name &&
+              (app.name
                 .toLocaleLowerCase()
-                .includes(filter.displayName.toLocaleLowerCase()))
+                .includes(filter.displayName.toLocaleLowerCase()) ||
+                app.team.name
+                  .toLocaleLowerCase()
+                  .includes(filter.displayName.toLocaleLowerCase()))) ||
+            (filter.type === FilterType.team &&
+              app.team.name === filter.displayName)
           );
         });
         return passesNameFilter && passesFilterList;

--- a/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsList.tsx
@@ -26,7 +26,7 @@ export function AppsList({
 
   // This is the App[][] of apps per team.
   const { isLoading, data: appsListPerTeam } = useListAppsForTeams(teams);
-  // This is the flattened App[] that includes team information.
+  // This is the flattened AppWithTeam[] that includes team information.
   const appsList = useMemo<AppWithTeam[]>(() => {
     if (!appsListPerTeam) {
       return [];

--- a/projects/ui/src/Components/Apps/PageContent/AppsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsPageContent.tsx
@@ -13,27 +13,32 @@ export function AppsPageContent() {
 
   const [allFilters, setAllFilters] = useState<FilterPair[]>([]);
   const [nameFilter, setNameFilter] = useState<string>("");
+  const [teamFilter, setTeamFilter] = useState<string>("");
 
   const filters = {
     allFilters,
     setAllFilters,
     nameFilter,
     setNameFilter,
+    teamFilter,
+    setTeamFilter,
   };
 
   return (
     <div>
-      <AppsFilter filters={filters} />
       <ErrorBoundary fallback="There was an issue loading the list of Apps">
         {isLoading || teams === undefined ? (
           // Make sure the teams are finished loading since they are a dependency.
           <Loading message="Loading..." />
         ) : (
-          <AppsList
-            teams={teams}
-            allFilters={allFilters}
-            nameFilter={nameFilter}
-          />
+          <>
+            <AppsFilter filters={filters} teams={teams} />
+            <AppsList
+              teams={teams}
+              allFilters={allFilters}
+              nameFilter={nameFilter}
+            />
+          </>
         )}
       </ErrorBoundary>
     </div>

--- a/projects/ui/src/Components/Apps/PageContent/AppsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppsPageContent.tsx
@@ -1,18 +1,20 @@
 import { useState } from "react";
+import { di } from "react-magnetic-di";
+import { useListTeams } from "../../../Apis/hooks";
 import { FilterPair } from "../../../Utility/filter-utility";
 import { ErrorBoundary } from "../../Common/ErrorBoundary";
+import { Loading } from "../../Common/Loading";
 import { AppsFilter } from "./AppsFilter";
 import { AppsList } from "./AppsList";
 
 export function AppsPageContent() {
+  di(useListTeams);
+  const { isLoading, data: teams } = useListTeams();
+
   const [allFilters, setAllFilters] = useState<FilterPair[]>([]);
   const [nameFilter, setNameFilter] = useState<string>("");
 
-  const [usingGridView, setUsingGridView] = useState(false);
-
   const filters = {
-    showingGrid: usingGridView,
-    setShowingGrid: setUsingGridView,
     allFilters,
     setAllFilters,
     nameFilter,
@@ -22,12 +24,17 @@ export function AppsPageContent() {
   return (
     <div>
       <AppsFilter filters={filters} />
-      <ErrorBoundary fallback="There was an issue loading the list of APIs">
-        <AppsList
-          allFilters={allFilters}
-          nameFilter={nameFilter}
-          usingGridView={usingGridView}
-        />
+      <ErrorBoundary fallback="There was an issue loading the list of Apps">
+        {isLoading || teams === undefined ? (
+          // Make sure the teams are finished loading since they are a dependency.
+          <Loading message="Loading..." />
+        ) : (
+          <AppsList
+            teams={teams}
+            allFilters={allFilters}
+            nameFilter={nameFilter}
+          />
+        )}
       </ErrorBoundary>
     </div>
   );

--- a/projects/ui/src/Components/Common/Banner/BannerHeading.tsx
+++ b/projects/ui/src/Components/Common/Banner/BannerHeading.tsx
@@ -127,7 +127,7 @@ export function BannerHeading({
   breadcrumbItems,
 }: {
   title: React.ReactNode;
-  description: string;
+  description: React.ReactNode;
   fullIcon?: React.ReactNode;
   additionalContent?: React.ReactNode;
   tall?: boolean;

--- a/projects/ui/src/Components/Common/Button.tsx
+++ b/projects/ui/src/Components/Common/Button.tsx
@@ -14,8 +14,7 @@ export const makeStyledButtonCSS = (theme: Theme) => css`
   border-radius: 2px;
   height: 40px;
   min-width: 90px;
-  line-height: 40px;
-  padding: 0 10px;
+  padding: 0 22px;
   color: white;
   font-size: 14px;
   font-weight: 600;
@@ -25,7 +24,7 @@ export const makeStyledButtonCSS = (theme: Theme) => css`
   // Primary states
   //
   border: 1px solid ${theme.januaryGrey};
-  background-color: ${theme.primary};
+  background-color: ${theme.lakeBlue};
   &:hover {
     background-color: ${theme.primaryLight10};
   }
@@ -89,6 +88,25 @@ export const makeStyledButtonCSS = (theme: Theme) => css`
     }
     &:active {
       background-color: ${theme.midGreenLight20};
+    }
+  }
+
+  //
+  // Outline states
+  //
+  &.outline {
+    color: ${theme.lakeBlue};
+    border: 1px solid ${theme.lakeBlue};
+    background-color: white;
+    &:hover {
+      color: white;
+      background-color: ${theme.primaryLight10};
+      border: none;
+    }
+    &:active {
+      color: white;
+      background-color: ${theme.primaryLight20};
+      border: none;
     }
   }
 

--- a/projects/ui/src/Components/Common/Modal.tsx
+++ b/projects/ui/src/Components/Common/Modal.tsx
@@ -1,19 +1,21 @@
 import { StyledMantineModal } from "./Modal.style";
 
-export function Modal({
-  onClose,
-  headContent,
-  title,
-  bodyContent,
-  className,
-}: {
+export interface ModalProps {
   onClose: () => any;
   headContent: JSX.Element; // ususally just an icon
   title?: string;
   bodyContent?: JSX.Element;
   /** The clasNames are applied to the .mantine-Modal-root, which is outside the modal and page overlay. */
   className?: string;
-}) {
+}
+
+export function Modal({
+  onClose,
+  headContent,
+  title,
+  bodyContent,
+  className,
+}: ModalProps) {
   // The modal "mask" is overriden in "main.scss" rather than with
   //   the overlayProps so that we have easy access to our
   //   color constants.

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -200,16 +200,16 @@ export function Header() {
             // TODO: Check which routes here require auth. 
             */}
             <NavLink
-              to={"/apps"}
-              className={`navLink ${inAppsArea ? "active" : ""}`}
-            >
-              Apps
-            </NavLink>
-            <NavLink
               to={"/teams"}
               className={`navLink ${inTeamsArea ? "active" : ""}`}
             >
               Teams
+            </NavLink>
+            <NavLink
+              to={"/apps"}
+              className={`navLink ${inAppsArea ? "active" : ""}`}
+            >
+              Apps
             </NavLink>
             <div className="divider" />
             <ErrorBoundary fallback="Access issues" class="horizontalError">

--- a/projects/ui/src/Components/Teams/Modals/CreateNewTeamModal.tsx
+++ b/projects/ui/src/Components/Teams/Modals/CreateNewTeamModal.tsx
@@ -1,6 +1,7 @@
 import { CloseButton, Flex, Input } from "@mantine/core";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
+import { di } from "react-magnetic-di";
 import { useCreateTeamMutation } from "../../../Apis/hooks";
 import { FormModalStyles } from "../../../Styles/shared/FormModalStyles";
 import { Button } from "../../Common/Button";
@@ -12,14 +13,27 @@ const CreateNewTeamModal = ({
   opened: boolean;
   onClose: () => void;
 }) => {
+  di(useCreateTeamMutation);
   const [teamName, setTeamName] = useState("");
   const [teamDescription, setTeamDescription] = useState("");
 
+  const formRef = useRef<HTMLFormElement>(null);
+  const isFormDisabled = !formRef.current?.checkValidity();
+  const resetForm = () => {
+    setTeamName("");
+    setTeamDescription("");
+  };
+
   const { trigger: createTeam } = useCreateTeamMutation();
 
-  const onSubmit = (e?: FormEvent) => {
+  const onSubmit = async (e?: FormEvent) => {
     e?.preventDefault();
-    toast.promise(
+    // Do HTML form validation.
+    formRef.current?.reportValidity();
+    if (isFormDisabled) {
+      return;
+    }
+    await toast.promise(
       createTeam({ name: teamName, description: teamDescription }),
       {
         error: "There was an error creating the team.",
@@ -27,7 +41,13 @@ const CreateNewTeamModal = ({
         success: "Created the team!",
       }
     );
+    onClose();
   };
+
+  // Reset the form on close.
+  useEffect(() => {
+    if (!opened) resetForm();
+  }, [opened]);
 
   return (
     <FormModalStyles.CustomModal
@@ -45,11 +65,13 @@ const CreateNewTeamModal = ({
         <CloseButton title="Close modal" size={"30px"} />
       </FormModalStyles.HeaderContainer>
       <FormModalStyles.HorizLine />
-      <FormModalStyles.BodyContainerForm onSubmit={onSubmit}>
+      <FormModalStyles.BodyContainerForm ref={formRef} onSubmit={onSubmit}>
         <FormModalStyles.InputContainer>
           <label htmlFor="team-name-input">Team Name</label>
           <Input
             id="team-name-input"
+            required
+            autoComplete="off"
             value={teamName}
             onChange={(e) => setTeamName(e.target.value)}
           />
@@ -62,15 +84,17 @@ const CreateNewTeamModal = ({
             // so that newlines are preserved when saved.
             // <Textarea
             id="team-description-input"
+            required
+            autoComplete="off"
             value={teamDescription}
             onChange={(e) => setTeamDescription(e.target.value)}
           />
         </FormModalStyles.InputContainer>
         <Flex justify={"flex-end"} gap="20px">
-          <Button className="outline" onClick={onClose}>
+          <Button className="outline" onClick={onClose} type="button">
             Cancel
           </Button>
-          <Button onClick={onSubmit} type="submit">
+          <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">
             Create Team
           </Button>
         </Flex>

--- a/projects/ui/src/Components/Teams/Modals/CreateNewTeamModal.tsx
+++ b/projects/ui/src/Components/Teams/Modals/CreateNewTeamModal.tsx
@@ -1,0 +1,82 @@
+import { CloseButton, Flex, Input } from "@mantine/core";
+import { FormEvent, useState } from "react";
+import toast from "react-hot-toast";
+import { useCreateTeamMutation } from "../../../Apis/hooks";
+import { FormModalStyles } from "../../../Styles/shared/FormModalStyles";
+import { Button } from "../../Common/Button";
+
+const CreateNewTeamModal = ({
+  opened,
+  onClose,
+}: {
+  opened: boolean;
+  onClose: () => void;
+}) => {
+  const [teamName, setTeamName] = useState("");
+  const [teamDescription, setTeamDescription] = useState("");
+
+  const { trigger: createTeam } = useCreateTeamMutation();
+
+  const onSubmit = (e?: FormEvent) => {
+    e?.preventDefault();
+    toast.promise(
+      createTeam({ name: teamName, description: teamDescription }),
+      {
+        error: "There was an error creating the team.",
+        loading: "Creating the team...",
+        success: "Created the team!",
+      }
+    );
+  };
+
+  return (
+    <FormModalStyles.CustomModal
+      onClose={onClose}
+      opened={opened}
+      size={"800px"}
+    >
+      <FormModalStyles.HeaderContainer>
+        <div>
+          <FormModalStyles.Title>Create a New Team</FormModalStyles.Title>
+          <FormModalStyles.Subtitle>
+            Create a new team.
+          </FormModalStyles.Subtitle>
+        </div>
+        <CloseButton title="Close modal" size={"30px"} />
+      </FormModalStyles.HeaderContainer>
+      <FormModalStyles.HorizLine />
+      <FormModalStyles.BodyContainerForm onSubmit={onSubmit}>
+        <FormModalStyles.InputContainer>
+          <label htmlFor="team-name-input">Team Name</label>
+          <Input
+            id="team-name-input"
+            value={teamName}
+            onChange={(e) => setTeamName(e.target.value)}
+          />
+        </FormModalStyles.InputContainer>
+        <FormModalStyles.InputContainer>
+          <label htmlFor="team-description-input">Team Description</label>
+          <Input
+            // This could be a Textarea if newlines exist in the description.
+            // Then we would need to get the text content using a ref
+            // so that newlines are preserved when saved.
+            // <Textarea
+            id="team-description-input"
+            value={teamDescription}
+            onChange={(e) => setTeamDescription(e.target.value)}
+          />
+        </FormModalStyles.InputContainer>
+        <Flex justify={"flex-end"} gap="20px">
+          <Button className="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={onSubmit} type="submit">
+            Create Team
+          </Button>
+        </Flex>
+      </FormModalStyles.BodyContainerForm>
+    </FormModalStyles.CustomModal>
+  );
+};
+
+export default CreateNewTeamModal;

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -4,6 +4,7 @@ import { NavLink } from "react-router-dom";
 import { Team } from "../../../../Apis/api-types";
 import { useListAppsForTeam, useListMembers } from "../../../../Apis/hooks";
 import { Icon } from "../../../../Assets/Icons";
+import { CardStyles } from "../../../../Styles/shared/Card.style";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { getTeamDetailsLink } from "../../../../Utility/link-builders";
 import { SubscriptionInfoCardStyles } from "../../../Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style";
@@ -34,9 +35,9 @@ export function TeamSummaryGridCard({ team }: { team: Team }) {
                 {isLoadingApps ? (
                   <Loading small />
                 ) : (
-                  <SubscriptionInfoCardStyles.Text>
+                  <CardStyles.SmallerText>
                     {teamApps?.length} App{teamApps?.length === 1 ? "" : "s"}
-                  </SubscriptionInfoCardStyles.Text>
+                  </CardStyles.SmallerText>
                 )}
               </Flex>
               |
@@ -45,16 +46,14 @@ export function TeamSummaryGridCard({ team }: { team: Team }) {
                 {isLoadingMembers ? (
                   <Loading small />
                 ) : (
-                  <SubscriptionInfoCardStyles.Text>
+                  <CardStyles.SmallerText>
                     {teamMembers?.length} Member
                     {teamMembers?.length === 1 ? "" : "s"}
-                  </SubscriptionInfoCardStyles.Text>
+                  </CardStyles.SmallerText>
                 )}
               </Flex>
             </Flex>
-            <GridCardStyles.Description>
-              {team.description}
-            </GridCardStyles.Description>
+            <CardStyles.Description>{team.description}</CardStyles.Description>
           </Flex>
         </Box>
       </div>

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -2,7 +2,7 @@ import { Box, Flex } from "@mantine/core";
 import { di } from "react-magnetic-di";
 import { NavLink } from "react-router-dom";
 import { Team } from "../../../../Apis/api-types";
-import { useListApps, useListMembers } from "../../../../Apis/hooks";
+import { useListAppsForTeam, useListMembers } from "../../../../Apis/hooks";
 import { Icon } from "../../../../Assets/Icons";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { getTeamDetailsLink } from "../../../../Utility/link-builders";
@@ -13,9 +13,9 @@ import { Loading } from "../../../Common/Loading";
  * MAIN COMPONENT
  **/
 export function TeamSummaryGridCard({ team }: { team: Team }) {
-  di(useListApps, useListMembers);
+  di(useListAppsForTeam, useListMembers);
 
-  const { isLoading: isLoadingApps, data: teamApps } = useListApps(team.id);
+  const { isLoading: isLoadingApps, data: teamApps } = useListAppsForTeam(team);
   const { isLoading: isLoadingMembers, data: teamMembers } = useListMembers(
     team.id
   );

--- a/projects/ui/src/Components/Teams/TeamsPage.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.tsx
@@ -1,19 +1,38 @@
+import { Box } from "@mantine/core";
+import { useState } from "react";
 import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
+import { Button } from "../Common/Button";
 import { PageContainer } from "../Common/PageContainer";
+import CreateNewTeamModal from "./Modals/CreateNewTeamModal";
 import { TeamsList } from "./PageContent/TeamsList";
 
 export function TeamsPage() {
+  const [modalOpen, setModalOpen] = useState(false);
+
   return (
     <PageContainer>
       <BannerHeading
         title={<BannerHeadingTitle text={"Teams"} logo={<Icon.TeamsIcon />} />}
-        description={"Browse the list of Teams in this portal."}
+        description={
+          <>
+            Browse the list of teams in this portal.
+            <Box pt={"20px"}>
+              <Button onClick={() => setModalOpen(true)}>
+                CREATE NEW TEAM
+              </Button>
+            </Box>
+          </>
+        }
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Teams" }]}
       />
-
       <TeamsList />
+      {/* {modalOpen && <CreateNewTeamModal onClose={() => setModalOpen(false)} />} */}
+      <CreateNewTeamModal
+        opened={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
     </PageContainer>
   );
 }

--- a/projects/ui/src/Components/Teams/TeamsPage.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.tsx
@@ -28,7 +28,6 @@ export function TeamsPage() {
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Teams" }]}
       />
       <TeamsList />
-      {/* {modalOpen && <CreateNewTeamModal onClose={() => setModalOpen(false)} />} */}
       <CreateNewTeamModal
         opened={modalOpen}
         onClose={() => setModalOpen(false)}

--- a/projects/ui/src/Context/AppContext.tsx
+++ b/projects/ui/src/Context/AppContext.tsx
@@ -11,6 +11,8 @@ interface IAppContext extends AppProviderProps {
   isMobileView: boolean;
   isDarkMode: boolean;
   setIsDarkMode: (isDarkMode: boolean) => void;
+  preferGridView: boolean;
+  setPreferGridView: (newValue: boolean) => void;
   pageContentIsWide: boolean;
 }
 
@@ -44,12 +46,21 @@ export const AppContextProvider = (props: AppProviderProps) => {
     localStorage.setItem("dark-mode", isDarkMode ? "true" : "false");
   }, [isDarkMode]);
 
+  const [preferGridView, setPreferGridView] = useState(
+    localStorage.getItem("prefer-grid-view") === "true"
+  );
+  useEffect(() => {
+    localStorage.setItem("prefer-grid-view", preferGridView ? "true" : "false");
+  }, [preferGridView]);
+
   return (
     <AppContext.Provider
       value={{
         isMobileView,
         isDarkMode,
         setIsDarkMode,
+        preferGridView,
+        setPreferGridView,
         pageContentIsWide: routeLocation.pathname.includes("/api-details/"),
       }}
     >

--- a/projects/ui/src/Styles/shared/Card.style.tsx
+++ b/projects/ui/src/Styles/shared/Card.style.tsx
@@ -1,0 +1,21 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+
+// TODO: Consolidate styles from ./GridCard.style.tsx and ListCard.style.tsx here, refactor, and reduce the amount of styles.
+export namespace CardStyles {
+  export const Title = styled.div`
+    line-height: 30px;
+    font-size: 28px;
+    font-weight: 600;
+    margin-bottom: 10px;
+  `;
+
+  export const Description = styled.div(
+    ({ theme }) => css`
+      text-align: left;
+      color: ${theme.septemberGrey};
+      font-size: 1rem;
+      margin-bottom: 10px;
+    `
+  );
+}

--- a/projects/ui/src/Styles/shared/Card.style.tsx
+++ b/projects/ui/src/Styles/shared/Card.style.tsx
@@ -18,4 +18,8 @@ export namespace CardStyles {
       margin-bottom: 10px;
     `
   );
+
+  export const SmallerText = styled.span`
+    font-size: 0.95rem;
+  `;
 }

--- a/projects/ui/src/Styles/shared/FormModalStyles.tsx
+++ b/projects/ui/src/Styles/shared/FormModalStyles.tsx
@@ -1,0 +1,71 @@
+import styled from "@emotion/styled";
+import { Flex, Modal } from "@mantine/core";
+import { colors } from "../colors";
+import { borderRadiusConstants } from "../constants";
+import { svgColorReplace } from "../utils";
+
+// Note: The theme variable doesn't work here because the
+// modal is generated outside of the emotion provider.
+export namespace FormModalStyles {
+  const modalDefaultPadding = "30px";
+
+  export const CustomModal = styled(Modal)`
+    // Resets the mantine modal extra styles.
+    .mantine-Modal-content {
+      border-radius: ${borderRadiusConstants.small};
+    }
+    .mantine-Modal-body {
+      display: contents;
+    }
+    .mantine-Modal-header {
+      display: none;
+    }
+  `;
+
+  export const HeaderContainer = styled(Flex)`
+    padding: ${modalDefaultPadding};
+    padding-bottom: 0px;
+    gap: 0px;
+    justify-content: space-between;
+    // The close button
+    button {
+      margin-top: 10px;
+      width: fit-content;
+      height: fit-content;
+      ${svgColorReplace(colors.aprilGrey)}
+    }
+  `;
+
+  export const BodyContainerForm = styled.form`
+    padding: ${modalDefaultPadding};
+    padding-top: 0px;
+    flex-direction: column;
+    display: flex;
+    gap: 20px;
+  `;
+
+  export const Title = styled.div`
+    font-size: 1.7rem;
+    padding-bottom: 3px;
+  `;
+
+  export const Subtitle = styled.div`
+    font-size: 1rem;
+    color: ${colors.septemberGrey};
+  `;
+
+  export const HorizLine = styled.div`
+    width: 100%;
+    height: 0px;
+    border-top: 1px solid ${colors.aprilGrey};
+    margin: 20px 0px;
+  `;
+
+  export const InputContainer = styled.div`
+    label {
+      font-size: 1.25rem;
+      padding-bottom: 8px;
+      display: block;
+    }
+  `;
+}

--- a/projects/ui/src/Styles/shared/FormModalStyles.tsx
+++ b/projects/ui/src/Styles/shared/FormModalStyles.tsx
@@ -13,6 +13,7 @@ export namespace FormModalStyles {
     // Resets the mantine modal extra styles.
     .mantine-Modal-content {
       border-radius: ${borderRadiusConstants.small};
+      overflow: visible;
     }
     .mantine-Modal-body {
       display: contents;

--- a/projects/ui/src/Styles/shared/GridCard.style.tsx
+++ b/projects/ui/src/Styles/shared/GridCard.style.tsx
@@ -5,11 +5,19 @@ import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../PrimaryTrimmedSmall
 import { borderRadiusConstants } from "../constants";
 
 export namespace GridCardStyles {
+  export const Title = styled.div`
+    line-height: 30px;
+    font-size: 28px;
+    font-weight: 600;
+    margin-bottom: 10px;
+  `;
+
   export const Description = styled.div(
     ({ theme }) => css`
       text-align: left;
       color: ${theme.septemberGrey};
-      font-size: 0.95rem;
+      font-size: 1rem;
+      margin-bottom: 10px;
     `
   );
 
@@ -19,12 +27,11 @@ export namespace GridCardStyles {
       flex-direction: column;
 
       height: 100%;
-      /* min-height: 260px; */
       min-height: 100px;
       border-radius: ${borderRadiusConstants.small};
       box-shadow: 1px 1px 5px ${theme.splashBlue};
-
       border: 1px solid ${theme.splashBlue};
+
       background: ${whiteBg ? "white" : theme.lightGreyTransparent};
       color: ${theme.defaultColoredText};
       text-align: center;
@@ -115,15 +122,19 @@ export namespace GridCardStyles {
       //
       // Shared styles between API summary cards
       //
+      box-shadow: 1px 1px 5px ${theme.splashBlue};
+      border: 1px solid ${theme.splashBlue};
       transition: 0.1s box-shadow, 0.1s outline-color;
       outline-offset: 2px;
       outline: 2px solid transparent;
       &:hover {
         outline-color: ${theme.lakeBlue};
+        outline-width: 2px;
       }
       &:active {
         outline-color: ${theme.pondBlue};
         box-shadow: 0 0 5px ${theme.pondBlue};
+        outline-width: 2px;
       }
     `
   ).withComponent(NavLink);

--- a/projects/ui/src/Styles/shared/GridCard.style.tsx
+++ b/projects/ui/src/Styles/shared/GridCard.style.tsx
@@ -5,22 +5,6 @@ import { makePrimaryTrimmedSmallWhiteContainerCSS } from "../PrimaryTrimmedSmall
 import { borderRadiusConstants } from "../constants";
 
 export namespace GridCardStyles {
-  export const Title = styled.div`
-    line-height: 30px;
-    font-size: 28px;
-    font-weight: 600;
-    margin-bottom: 10px;
-  `;
-
-  export const Description = styled.div(
-    ({ theme }) => css`
-      text-align: left;
-      color: ${theme.septemberGrey};
-      font-size: 1rem;
-      margin-bottom: 10px;
-    `
-  );
-
   export const GridCard = styled.div<{ whiteBg?: boolean }>(
     ({ theme, whiteBg }) => css`
       display: flex;

--- a/projects/ui/src/Styles/shared/ListCard.style.tsx
+++ b/projects/ui/src/Styles/shared/ListCard.style.tsx
@@ -9,9 +9,7 @@ export namespace ListCardStyles {
       margin-bottom: 30px;
       border-radius: ${borderRadiusConstants.small};
 
-      border: 1px solid ${theme.splashBlue};
       background: ${theme.lightGreyTransparent};
-      box-shadow: 0px 2px 8px ${theme.darkGreyTransparent};
 
       .content {
         display: flex;
@@ -121,6 +119,8 @@ export namespace ListCardStyles {
       //
       // Shared styles between API summary cards
       //
+      box-shadow: 1px 1px 5px ${theme.splashBlue};
+      border: 1px solid ${theme.splashBlue};
       transition: 0.1s box-shadow, 0.1s outline-color;
       outline-offset: 2px;
       outline: 2px solid transparent;

--- a/projects/ui/src/Utility/filter-utility.ts
+++ b/projects/ui/src/Utility/filter-utility.ts
@@ -7,6 +7,7 @@ export enum FilterType {
   name,
   keyValuePair,
   apiType,
+  team,
 }
 export type FilterPair = { displayName: string; type: FilterType };
 


### PR DESCRIPTION
This updates the apps and teams pages and includes modals for creating apps and teams, using HTML form validation. It also makes the grid/list view preference persistent.


Here is a video of creating a team:

https://github.com/solo-io/dev-portal-starter/assets/4720646/b57b8e1e-30be-4a23-8072-248b5d22c0e4


Here is a video of creating an app for that team:

https://github.com/solo-io/dev-portal-starter/assets/4720646/7947a490-204d-4cb2-8e73-2707f95f5a14

This is a screenshot of the apps page list card view:

<img width="1199" alt="Screenshot 2024-03-06 at 1 39 11 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/dbdd7534-c297-438a-a0aa-99f7fea47d9e">

Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/15187
Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/15189