### PR TITLE
Charlesthebird/apps page details

### DIFF
--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -84,6 +84,10 @@ export type Member = {
   synced: boolean;
 };
 
+export enum SubscriptionStatus {
+  APPROVED = "approved",
+  PENDING = "pending",
+}
 export type Subscription = {
   id: string;
   createdAt: string;
@@ -95,6 +99,10 @@ export type Subscription = {
   applicationId: string;
   apiProductId: string;
   usagePlanId: string;
+};
+
+export type ErrorMessageResponse = {
+  message: string;
 };
 
 type SchemaPropertyType = "string" | "integer" | "array" | "object";

--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -84,6 +84,19 @@ export type Member = {
   synced: boolean;
 };
 
+export type Subscription = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  requestedAt: string;
+  approved: boolean;
+  approvedAt: string;
+  applicationId: string;
+  apiProductId: string;
+  usagePlanId: string;
+};
+
 type SchemaPropertyType = "string" | "integer" | "array" | "object";
 export type APISchema = {
   components?: {

--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -8,32 +8,15 @@ export type User = {
   name: string;
   email: string;
   username: string;
+  // TODO: Once auth is working, check if we can get admin info here and update the areas that use admin endpoints (e.g. subscriptions areas).
+  // admin: string;
 };
 
-type RateLimitPolicy = {
-  unit: "UNKNOWN" | "SECOND" | "MINUTE" | "HOUR" | "DAY";
-  requestsPerUnit: number;
-};
-
-type AuthPolicy = {
-  authType: string;
-};
-
-export type UsagePlan = {
-  name: string;
-  authPolicies: AuthPolicy[];
-  rateLimitPolicy: RateLimitPolicy;
-  apiIds: string[];
-};
-
-export type APIKey = {
-  name: string;
-  id: string;
-  // APIKey is returned only once when the API key is created.
-  apiKey: string | undefined;
-  metadata?: Record<string, string> | undefined;
-};
-
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+// TODO: Remove these old types and update API pages.
 export type APIVersion = {
   apiId: string;
   apiVersion: string;
@@ -49,6 +32,58 @@ export type APIProduct = {
   apiProductId: string;
   apiProductDisplayName: string;
   apiVersions: APIVersion[];
+};
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+
+export type ApiProductSummary = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  name: string;
+  description: string;
+  versionsCount: number;
+};
+
+export type ApiProductDetails = Omit<ApiProductSummary, "versionsCount"> & {
+  // Inherited fields, same as ApiProductSummary
+  // id: string;
+  // createdAt: string;
+  // updatedAt: string;
+  // deletedAt: string;
+  // name: string;
+  // description: string;
+  autoApproval: boolean;
+  contactEmail: string;
+  metadata: Record<string, string>;
+  public: boolean;
+  versions: ApiVersion[];
+  subscriptions: Subscription[];
+};
+
+export type ApiVersion = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  name: string;
+  title: string;
+  documentation: string;
+  termsOfService: string;
+  license: string;
+  lifecycle: string;
+  status: string; // 'published',
+  backingService: string;
+  apiSpec: string;
+  visible: boolean;
+  oauthEnabled: boolean;
+  apiKeyEnabled: boolean;
+  public: boolean;
+  metadata: Record<string, string>;
+  apiProductId: string;
 };
 
 export type App = {

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -169,6 +169,7 @@ export function useGetApiProductDetails(id?: string) {
 
 // Subscriptions
 const SUBSCRIPTIONS_SWR_KEY = "subscriptions";
+// this is an admin endpoint
 export function useListSubscriptionsForStatus(status: SubscriptionStatus) {
   const swrResponse = useSwrWithAuth<Subscription[] | ErrorMessageResponse>(
     `/subscriptions?status=${status}`,
@@ -182,19 +183,12 @@ export function useListSubscriptionsForStatus(status: SubscriptionStatus) {
   }, [swrResponse.data]);
   return swrResponse;
 }
-
+// this is NOT an admin endpoint
 export function useListSubscriptionsForApp(appId: string) {
-  const swrResponse = useSwrWithAuth<Subscription[] | ErrorMessageResponse>(
+  return useSwrWithAuth<Subscription[]>(
     `/apps/${appId}/subscriptions`,
     SUBSCRIPTIONS_SWR_KEY
   );
-  useEffect(() => {
-    if (!!swrResponse.data && "message" in swrResponse.data) {
-      // eslint-disable-next-line no-console
-      console.warn(swrResponse.data.message);
-    }
-  }, [swrResponse.data]);
-  return swrResponse;
 }
 
 //

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -2,7 +2,15 @@ import { useContext } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import useSWRMutation from "swr/mutation";
 import { PortalAuthContext } from "../Context/PortalAuthContext";
-import { APIProduct, APISchema, App, Member, Team, User } from "./api-types";
+import {
+  APIProduct,
+  APISchema,
+  App,
+  Member,
+  Subscription,
+  Team,
+  User,
+} from "./api-types";
 
 let _portalServerUrl = import.meta.env.VITE_PORTAL_SERVER_URL;
 if (
@@ -99,9 +107,7 @@ export function useGetCurrentUser() {
   return useSwrWithAuth<User>("/me");
 }
 
-export function useListApis() {
-  return useSwrWithAuth<APIProduct[]>("/apis");
-}
+// Apps
 export function useListAppsForTeam(team: Team) {
   return useSwrWithAuth<App[]>(`/teams/${team.id}/apps`);
 }
@@ -111,14 +117,32 @@ export function useListAppsForTeams(teams: Team[]) {
     teams.map((t) => `/teams/${t.id}/apps`)
   );
 }
-export function useListMembers(teamId: string) {
-  return useSwrWithAuth<Member[]>(`/teams/${teamId}/members`);
+export function useGetAppDetails(id?: string) {
+  return useSwrWithAuth<App>(`/apps/${id}`);
 }
+
+// Teams
 export function useListTeams() {
   return useSwrWithAuth<Team[]>(`/teams`);
 }
+export function useListMembers(teamId: string) {
+  return useSwrWithAuth<Member[]>(`/teams/${teamId}/members`);
+}
+export function useGetTeamDetails(id?: string) {
+  return useSwrWithAuth<Team>(`/teams/${id}`);
+}
+
+// APIs
+export function useListApis() {
+  return useSwrWithAuth<APIProduct[]>("/apis");
+}
 export function useGetApiDetails(id?: string) {
   return useSwrWithAuth<APISchema>(`/apis/${id}/schema`);
+}
+
+// Subscriptions
+export function useListSubscriptions() {
+  return useSwrWithAuth<Subscription[]>(`/subscriptions`);
 }
 
 //

--- a/projects/ui/src/Assets/Icons/Icons.tsx
+++ b/projects/ui/src/Assets/Icons/Icons.tsx
@@ -21,6 +21,7 @@ export { ReactComponent as NetworkOfCircles } from "./network-of-circles.svg";
 export { ReactComponent as NetworkHub } from "./network-hub.svg";
 export { ReactComponent as OpenApiIcon } from "./OpenAPI-icon.svg";
 export { ReactComponent as Pencil } from "./pencil.svg";
+export { ReactComponent as PlusIcon } from "./plus-icon.svg";
 export { ReactComponent as Refresh } from "./refresh-icon.svg";
 export { ReactComponent as RightArrow } from "./right-arrow.svg";
 export { ReactComponent as SlashedCopy } from "./slashed-copy.svg";

--- a/projects/ui/src/Assets/Icons/plus-icon.svg
+++ b/projects/ui/src/Assets/Icons/plus-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 19 19">
+  <g id="plus-symbol" transform="translate(-0.266 -0.267)">
+    <circle id="Ellipse_11" data-name="Ellipse 11" cx="9.5" cy="9.5" r="9.5" transform="translate(0.266 0.267)" fill="#0fac7c"/>
+    <line id="Line_47" data-name="Line 47" y2="9.123" transform="translate(9.633 4.903)" fill="none" stroke="#fff" stroke-width="1"/>
+    <line id="Line_48" data-name="Line 48" x2="9.123" transform="translate(4.903 9.633)" fill="none" stroke="#fff" stroke-width="1"/>
+  </g>
+</svg>

--- a/projects/ui/src/Components/Apis/ApisPage.tsx
+++ b/projects/ui/src/Components/Apis/ApisPage.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Loader, Tabs } from "@mantine/core";
 import { di } from "react-magnetic-di";
-import { useListApis, useListSubscriptions } from "../../Apis/hooks";
+import { SubscriptionStatus } from "../../Apis/api-types";
+import { useListApis, useListSubscriptionsForStatus } from "../../Apis/hooks";
 import { Icon } from "../../Assets/Icons";
 import { colors } from "../../Styles";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
@@ -36,9 +37,11 @@ export const subscriptionStateMap = {
 
 export function ApisPage() {
   di(useListApis);
-  const { isLoading } = useListApis();
+  const { isLoading: isLoadingApis } = useListApis();
   const { isLoading: isLoadingSubscriptions, data: subscriptions } =
-    useListSubscriptions();
+    useListSubscriptionsForStatus(SubscriptionStatus.PENDING);
+  const subscriptionsError = subscriptions && "message" in subscriptions;
+  const isLoading = isLoadingApis || isLoadingSubscriptions;
 
   return (
     <PageContainer>
@@ -54,6 +57,9 @@ export function ApisPage() {
         {isLoading ? (
           // Make sure the APIs are finished loading since they are a dependency of both tabs.
           <Loading message="Getting list of apis..." />
+        ) : subscriptionsError ? (
+          // If there was a subscriptions error message (aka if we aren't an admin), don't show the subscriptions.
+          <ApisTabContent />
         ) : (
           <Tabs defaultValue="apis">
             {/*
@@ -70,7 +76,7 @@ export function ApisPage() {
                       <Loader size={"20px"} color={colors.seaBlue} />
                     </Box>
                   ) : (
-                    subscriptions.length && (
+                    subscriptions.length > 0 && (
                       <ApisPageStyles.NumberInCircle>
                         {subscriptions.length}
                       </ApisPageStyles.NumberInCircle>

--- a/projects/ui/src/Components/Apis/ApisPage.tsx
+++ b/projects/ui/src/Components/Apis/ApisPage.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Loader, Tabs } from "@mantine/core";
 import { di } from "react-magnetic-di";
-import { useListApis } from "../../Apis/hooks";
+import { useListApis, useListSubscriptions } from "../../Apis/hooks";
 import { Icon } from "../../Assets/Icons";
 import { colors } from "../../Styles";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
@@ -34,30 +34,11 @@ export const subscriptionStateMap = {
   },
 };
 
-// TODO: Replace with real data
-const isLoadingSubscriptions = false;
-const subscriptions = [
-  {
-    subscriptionName: "Tracks v1.0",
-    appName: "App Name Lorem Ipsum",
-    usagePlanName: "Gold Usage Plan",
-    // Subscription is for the entire api product (not version-specific).
-    apiProductId: "catstronauts-rest-api",
-    state: SubscriptionState.PENDING,
-  },
-  {
-    subscriptionName: "Tracks v1.1",
-    appName: "App 2 Name",
-    usagePlanName: "Gold Usage Plan",
-    apiProductId: "catstronauts-rest-api",
-    state: SubscriptionState.REJECTED,
-  },
-];
-export type Subscription = (typeof subscriptions)[0];
-
 export function ApisPage() {
   di(useListApis);
   const { isLoading } = useListApis();
+  const { isLoading: isLoadingSubscriptions, data: subscriptions } =
+    useListSubscriptions();
 
   return (
     <PageContainer>
@@ -84,7 +65,7 @@ export function ApisPage() {
               <Tabs.Tab value="subs">
                 <Flex align="center" justify="center" gap={10}>
                   <span>Pending API Subscriptions</span>
-                  {isLoadingSubscriptions ? (
+                  {isLoadingSubscriptions || !subscriptions ? (
                     <Box pl={5} mb={-10}>
                       <Loader size={"20px"} color={colors.seaBlue} />
                     </Box>
@@ -106,7 +87,13 @@ export function ApisPage() {
               <ApisTabContent />
             </Tabs.Panel>
             <Tabs.Panel value="subs" pt={"xl"}>
-              <PendingSubscriptionTabContent subscriptions={subscriptions} />
+              {isLoadingSubscriptions || !subscriptions ? (
+                <Box pl={5} mb={-10}>
+                  <Loader size={"20px"} color={colors.seaBlue} />
+                </Box>
+              ) : (
+                <PendingSubscriptionTabContent subscriptions={subscriptions} />
+              )}
             </Tabs.Panel>
           </Tabs>
         )}

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/PendingSubscriptionTabContent.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/PendingSubscriptionTabContent.tsx
@@ -1,5 +1,6 @@
 import { Flex } from "@mantine/core";
 import { Subscription } from "../../../Apis/api-types";
+import { EmptyData } from "../../Common/EmptyData";
 import SubscriptionInfoCard from "./SubscriptionInfoCard";
 
 const PendingSubscriptionTabContent = ({
@@ -9,9 +10,13 @@ const PendingSubscriptionTabContent = ({
 }) => {
   return (
     <Flex gap={30} wrap={"wrap"}>
-      {subscriptions.map((s) => (
-        <SubscriptionInfoCard key={s.id} subscription={s} />
-      ))}
+      {subscriptions.length === 0 ? (
+        <EmptyData topic="pending API subscription" />
+      ) : (
+        subscriptions.map((s) => (
+          <SubscriptionInfoCard key={s.id} subscription={s} />
+        ))
+      )}
     </Flex>
   );
 };

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/PendingSubscriptionTabContent.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/PendingSubscriptionTabContent.tsx
@@ -1,5 +1,5 @@
 import { Flex } from "@mantine/core";
-import { Subscription } from "../ApisPage";
+import { Subscription } from "../../../Apis/api-types";
 import SubscriptionInfoCard from "./SubscriptionInfoCard";
 
 const PendingSubscriptionTabContent = ({
@@ -10,7 +10,7 @@ const PendingSubscriptionTabContent = ({
   return (
     <Flex gap={30} wrap={"wrap"}>
       {subscriptions.map((s) => (
-        <SubscriptionInfoCard key={s.subscriptionName} subscription={s} />
+        <SubscriptionInfoCard key={s.id} subscription={s} />
       ))}
     </Flex>
   );

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.style.tsx
@@ -60,19 +60,6 @@ export namespace SubscriptionInfoCardStyles {
     `
   );
 
-  export const CardTitle = styled.div`
-    font-size: 1.5rem;
-    font-weight: bold;
-    margin-bottom: 2px;
-  `;
-
-  export const CardTitleSmall = styled.div`
-    font-size: 1.25rem;
-    font-weight: bold;
-    margin-bottom: 2px;
-    text-align: left;
-  `;
-
   export const SubscriptionCardBadge = styled.div<{
     subscriptionState: SubscriptionState;
   }>(

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
@@ -2,11 +2,12 @@ import { Box, Flex } from "@mantine/core";
 import { useMemo } from "react";
 import { di } from "react-magnetic-di";
 import { NavLink } from "react-router-dom";
+import { Subscription } from "../../../Apis/api-types";
 import { useListApis } from "../../../Apis/hooks";
 import { AppIcon } from "../../../Assets/Icons/Icons";
 import { CardStyles } from "../../../Styles/shared/Card.style";
 import { getApiDetailsLink } from "../../../Utility/link-builders";
-import { Subscription, subscriptionStateMap } from "../ApisPage";
+import { SubscriptionState } from "../ApisPage";
 import { SubscriptionInfoCardStyles as Styles } from "./SubscriptionInfoCard.style";
 
 const SubscriptionInfoCard = ({
@@ -24,22 +25,26 @@ const SubscriptionInfoCard = ({
   }, [apisList, subscription]);
 
   return (
-    <Styles.Card subscriptionState={subscription.state}>
+    // <Styles.Card subscriptionState={subscription.state}>
+    <Styles.Card subscriptionState={SubscriptionState.REJECTED}>
       <Styles.Content>
         <Flex justify="space-between">
-          <Styles.CardTitle>{subscription.subscriptionName}</Styles.CardTitle>
-          <Styles.SubscriptionCardBadge subscriptionState={subscription.state}>
+          {/* <Styles.CardTitle>{subscription.subscriptionName}</Styles.CardTitle> */}
+          <Styles.CardTitle>{subscription.id}</Styles.CardTitle>
+          {/* <Styles.SubscriptionCardBadge subscriptionState={subscription.state}>
             {subscriptionStateMap[subscription.state].label}
-          </Styles.SubscriptionCardBadge>
+          </Styles.SubscriptionCardBadge> */}
         </Flex>
         <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
           <AppIcon width={20} />
           <CardStyles.SmallerText>
-            {subscription.appName}
+            {/* {subscription.appName} */}
+            {subscription.id}
           </CardStyles.SmallerText>
         </Flex>
         <CardStyles.SmallerText>
-          {subscription.usagePlanName}
+          {/* {subscription.usagePlanName} */}
+          {subscription.id}
         </CardStyles.SmallerText>
       </Styles.Content>
       {subscribedApi && (

--- a/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
+++ b/projects/ui/src/Components/Apis/PendingSubscriptionsTab/SubscriptionInfoCard.tsx
@@ -30,7 +30,9 @@ const SubscriptionInfoCard = ({
       <Styles.Content>
         <Flex justify="space-between">
           {/* <Styles.CardTitle>{subscription.subscriptionName}</Styles.CardTitle> */}
-          <Styles.CardTitle>{subscription.id}</Styles.CardTitle>
+          <CardStyles.TitleMedium bold>
+            {subscription.id}
+          </CardStyles.TitleMedium>
           {/* <Styles.SubscriptionCardBadge subscriptionState={subscription.state}>
             {subscriptionStateMap[subscription.state].label}
           </Styles.SubscriptionCardBadge> */}

--- a/projects/ui/src/Components/AppContentRoutes.tsx
+++ b/projects/ui/src/Components/AppContentRoutes.tsx
@@ -7,10 +7,12 @@ import {
 import { ApiDetailsPage } from "./ApiDetails/ApiDetailsPage";
 import { ApisPage } from "./Apis/ApisPage";
 import { AppsPage } from "./Apps/AppsPage";
+import AppDetailsPage from "./Apps/Details/AppDetailsPage";
 import { ErrorBoundary } from "./Common/ErrorBoundary";
 import LoggedOut from "./Common/LoggedOut";
 import { HomePage } from "./Home/HomePage";
 import { Footer } from "./Structure/Footer";
+import TeamDetailsPage from "./Teams/Details/TeamDetailsPage";
 import { TeamsPage } from "./Teams/TeamsPage";
 
 const MainContentContainer = styled.div`
@@ -79,10 +81,26 @@ function AppContentRoutes() {
           }
         />
         <Route
+          path="/apps/:appId"
+          element={
+            <ErrorBoundary fallback="There was an issue displaying the App details">
+              <AppDetailsPage />
+            </ErrorBoundary>
+          }
+        />
+        <Route
           path="/teams"
           element={
             <ErrorBoundary fallback="There was an issue displaying the list of Teams">
               <TeamsPage />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/teams/:teamId"
+          element={
+            <ErrorBoundary fallback="There was an issue displaying the Team details">
+              <TeamDetailsPage />
             </ErrorBoundary>
           }
         />

--- a/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
@@ -1,0 +1,5 @@
+const AppApiSubscriptionsSection = () => {
+  return <div>AppApiSubscriptionsSection</div>;
+};
+
+export default AppApiSubscriptionsSection;

--- a/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
@@ -2,10 +2,11 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Button, Flex } from "@mantine/core";
 import { useMemo, useState } from "react";
-import { App } from "../../../../Apis/api-types";
-import { useListSubscriptions } from "../../../../Apis/hooks";
+import { App, Subscription } from "../../../../Apis/api-types";
 import { Icon } from "../../../../Assets/Icons";
 import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
+import SubscriptionInfoCard from "../../../Apis/PendingSubscriptionsTab/SubscriptionInfoCard";
+import { EmptyData } from "../../../Common/EmptyData";
 
 const AddSubscriptionButtonContents = styled.div(
   ({ theme }) => css`
@@ -28,29 +29,20 @@ const AddSubscriptionButton = (props: typeof Button.defaultProps) => {
   );
 };
 
-const AppSubscriptionsSection = ({ app }: { app: App }) => {
-  const { isLoading: isLoadingSubscriptions, data: subscriptions } =
-    useListSubscriptions();
-
+const AppSubscriptionsSection = ({
+  app,
+  subscriptions,
+}: {
+  app: App;
+  subscriptions: Subscription[];
+}) => {
   const [showAddSubscriptionModal, setShowAddSubscriptionModal] =
     useState(false);
 
-  const [errorMessage, setErrorMessage] = useState<string>();
   const appSubscriptions = useMemo(() => {
-    try {
-      return subscriptions?.filter((s) => s.applicationId === app.id);
-    } catch {
-      const errMsg = (subscriptions as any).message;
-      if (!!errMsg) {
-        console.error(errMsg);
-        setErrorMessage(errMsg);
-      }
-    }
+    return subscriptions?.filter((s) => s.applicationId === app.id);
   }, [subscriptions, app]);
 
-  // if (!!errorMessage) {
-  //   return null;
-  // }
   return (
     <DetailsPageStyles.Section>
       <Flex justify={"space-between"}>
@@ -59,18 +51,12 @@ const AppSubscriptionsSection = ({ app }: { app: App }) => {
           onClick={() => setShowAddSubscriptionModal(true)}
         />
       </Flex>
-      {/* {isLoadingSubscriptions || appSubscriptions === undefined ? (
-        <Loading message="Loading Subscriptions" />
-      ) : ( */}
-      <>
-        <Flex justify={"flex-end"}></Flex>
-        <Flex wrap="wrap" gap={"20px"}>
-          {/* {appSubscriptions.map((s) => (
-            <SubscriptionInfoCard subscription={s} />
-          ))} */}
-        </Flex>
-      </>
-      {/* )} */}
+      {subscriptions.length === 0 && <EmptyData topic={"Subscriptions"} />}
+      <Flex wrap="wrap" gap={"20px"}>
+        {appSubscriptions.map((s) => (
+          <SubscriptionInfoCard subscription={s} />
+        ))}
+      </Flex>
     </DetailsPageStyles.Section>
   );
 };

--- a/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
@@ -7,6 +7,7 @@ import { Icon } from "../../../../Assets/Icons";
 import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
 import SubscriptionInfoCard from "../../../Apis/PendingSubscriptionsTab/SubscriptionInfoCard";
 import { EmptyData } from "../../../Common/EmptyData";
+import NewSubscriptionModal from "../Modals/NewSubscriptionModal";
 
 const AddSubscriptionButtonContents = styled.div(
   ({ theme }) => css`
@@ -57,6 +58,11 @@ const AppSubscriptionsSection = ({
           <SubscriptionInfoCard subscription={s} />
         ))}
       </Flex>
+      <NewSubscriptionModal
+        app={app}
+        opened={showAddSubscriptionModal}
+        onClose={() => setShowAddSubscriptionModal(false)}
+      />
     </DetailsPageStyles.Section>
   );
 };

--- a/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
@@ -51,7 +51,7 @@ const AppSubscriptionsSection = ({
           onClick={() => setShowAddSubscriptionModal(true)}
         />
       </Flex>
-      {subscriptions.length === 0 && <EmptyData topic={"Subscriptions"} />}
+      {subscriptions.length === 0 && <EmptyData topic={"API Subscription"} />}
       <Flex wrap="wrap" gap={"20px"}>
         {appSubscriptions.map((s) => (
           <SubscriptionInfoCard subscription={s} />

--- a/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
@@ -1,5 +1,78 @@
-const AppApiSubscriptionsSection = () => {
-  return <div>AppApiSubscriptionsSection</div>;
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Button, Flex } from "@mantine/core";
+import { useMemo, useState } from "react";
+import { App } from "../../../../Apis/api-types";
+import { useListSubscriptions } from "../../../../Apis/hooks";
+import { Icon } from "../../../../Assets/Icons";
+import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
+
+const AddSubscriptionButtonContents = styled.div(
+  ({ theme }) => css`
+    display: flex;
+    align-items: center;
+    color: ${theme.lakeBlue};
+    font-size: 0.8rem;
+    gap: 10px;
+  `
+);
+
+const AddSubscriptionButton = (props: typeof Button.defaultProps) => {
+  return (
+    <Button {...props} variant="subtle">
+      <AddSubscriptionButtonContents>
+        ADD SUBSCRIPTION
+        <Icon.PlusIcon />
+      </AddSubscriptionButtonContents>
+    </Button>
+  );
 };
 
-export default AppApiSubscriptionsSection;
+const AppSubscriptionsSection = ({ app }: { app: App }) => {
+  const { isLoading: isLoadingSubscriptions, data: subscriptions } =
+    useListSubscriptions();
+
+  const [showAddSubscriptionModal, setShowAddSubscriptionModal] =
+    useState(false);
+
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const appSubscriptions = useMemo(() => {
+    try {
+      return subscriptions?.filter((s) => s.applicationId === app.id);
+    } catch {
+      const errMsg = (subscriptions as any).message;
+      if (!!errMsg) {
+        console.error(errMsg);
+        setErrorMessage(errMsg);
+      }
+    }
+  }, [subscriptions, app]);
+
+  // if (!!errorMessage) {
+  //   return null;
+  // }
+  return (
+    <DetailsPageStyles.Section>
+      <Flex justify={"space-between"}>
+        <DetailsPageStyles.Title>API Subscriptions</DetailsPageStyles.Title>
+        <AddSubscriptionButton
+          onClick={() => setShowAddSubscriptionModal(true)}
+        />
+      </Flex>
+      {/* {isLoadingSubscriptions || appSubscriptions === undefined ? (
+        <Loading message="Loading Subscriptions" />
+      ) : ( */}
+      <>
+        <Flex justify={"flex-end"}></Flex>
+        <Flex wrap="wrap" gap={"20px"}>
+          {/* {appSubscriptions.map((s) => (
+            <SubscriptionInfoCard subscription={s} />
+          ))} */}
+        </Flex>
+      </>
+      {/* )} */}
+    </DetailsPageStyles.Section>
+  );
+};
+
+export default AppSubscriptionsSection;

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPage.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPage.tsx
@@ -1,10 +1,18 @@
 import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
+import { useGetAppDetails } from "../../../Apis/hooks";
+import { Loading } from "../../Common/Loading";
+import AppDetailsPageContent from "./AppDetailsPageContent";
 
 const AppDetailsPage = () => {
   di(useParams);
   const { appId } = useParams();
-  return <div>AppDetailsPage {appId}</div>;
+  const { isLoading, data: app } = useGetAppDetails(appId);
+
+  if (isLoading || !app) {
+    return <Loading />;
+  }
+  return <AppDetailsPageContent app={app} />;
 };
 
 export default AppDetailsPage;

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPage.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPage.tsx
@@ -1,0 +1,10 @@
+import { di } from "react-magnetic-di";
+import { useParams } from "react-router-dom";
+
+const AppDetailsPage = () => {
+  di(useParams);
+  const { appId } = useParams();
+  return <div>AppDetailsPage {appId}</div>;
+};
+
+export default AppDetailsPage;

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -1,0 +1,35 @@
+import { App } from "../../../Apis/api-types";
+import { BannerHeading } from "../../Common/Banner/BannerHeading";
+import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
+import { PageContainer } from "../../Common/PageContainer";
+import ApiSubscriptionsSection from "./ApiSubscriptionsSection/AppApiSubscriptionsSection";
+import AppAuthenticationSection from "./AuthenticationSection/AppAuthenticationSection";
+
+const AppDetailsPageContent = ({ app }: { app: App }) => {
+  return (
+    <PageContainer>
+      <BannerHeading
+        title={
+          <BannerHeadingTitle
+            text={app.name}
+            stylingTweaks={{
+              fontSize: "32px",
+              lineHeight: "36px",
+            }}
+          />
+        }
+        // fullIcon={<Icon.Bug />}
+        description={app.description}
+        breadcrumbItems={[
+          { label: "Home", link: "/" },
+          { label: "Apps", link: "/apps" },
+          { label: app.name },
+        ]}
+      />
+      <AppAuthenticationSection />
+      <ApiSubscriptionsSection />
+    </PageContainer>
+  );
+};
+
+export default AppDetailsPageContent;

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -4,7 +4,6 @@ import { App } from "../../../Apis/api-types";
 import { useListSubscriptionsForApp } from "../../../Apis/hooks";
 import { BannerHeading } from "../../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
-import { EmptyData } from "../../Common/EmptyData";
 import { PageContainer } from "../../Common/PageContainer";
 import ApiSubscriptionsSection from "./ApiSubscriptionsSection/AppApiSubscriptionsSection";
 import AppAuthenticationSection from "./AuthenticationSection/AppAuthenticationSection";
@@ -13,8 +12,6 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
   di(useListSubscriptionsForApp);
   const { isLoading: isLoadingSubscriptions, data: subscriptions } =
     useListSubscriptionsForApp(app.id);
-  const subscriptionsError =
-    subscriptions !== undefined && "message" in subscriptions;
 
   // Mock data for testing
   // app.idpClientId = "4df81266-f855-466d-8ded-699056780850";
@@ -42,20 +39,13 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
           { label: app.name },
         ]}
       />
-      {!appHasOAuthClient && subscriptionsError && (
-        <EmptyData
-          topicMessageOverride="App details unavailable."
-          message="Only admins may view app subscription data."
-        />
-      )}
       <Box px={30}>
         <Flex gap={"30px"} direction={"column"}>
           {appHasOAuthClient && <AppAuthenticationSection app={app} />}
-          {isLoadingSubscriptions ? (
+          {isLoadingSubscriptions || subscriptions === undefined ? (
             <Loader />
-          ) : // TODO: Figure out view for when the user isn't an admin. Currently just hides the section.
-          !!subscriptionsError ? null : (
-            <ApiSubscriptionsSection app={app} subscriptions={subscriptions!} />
+          ) : (
+            <ApiSubscriptionsSection app={app} subscriptions={subscriptions} />
           )}
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -26,8 +26,8 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
           { label: app.name },
         ]}
       />
-      <AppAuthenticationSection />
-      <ApiSubscriptionsSection />
+      <AppAuthenticationSection app={app} />
+      <ApiSubscriptionsSection app={app} />
     </PageContainer>
   );
 };

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -1,7 +1,7 @@
 import { Loader } from "@mantine/core";
 import { di } from "react-magnetic-di";
 import { App } from "../../../Apis/api-types";
-import { useListSubscriptions } from "../../../Apis/hooks";
+import { useListSubscriptionsForApp } from "../../../Apis/hooks";
 import { BannerHeading } from "../../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
 import { EmptyData } from "../../Common/EmptyData";
@@ -10,12 +10,11 @@ import ApiSubscriptionsSection from "./ApiSubscriptionsSection/AppApiSubscriptio
 import AppAuthenticationSection from "./AuthenticationSection/AppAuthenticationSection";
 
 const AppDetailsPageContent = ({ app }: { app: App }) => {
-  di(useListSubscriptions);
-  const {
-    isLoading: isLoadingSubscriptions,
-    data: subscriptions,
-    error: subscriptionsError,
-  } = useListSubscriptions();
+  di(useListSubscriptionsForApp);
+  const { isLoading: isLoadingSubscriptions, data: subscriptions } =
+    useListSubscriptionsForApp(app.id);
+  const subscriptionsError =
+    subscriptions !== undefined && "message" in subscriptions;
 
   const appHasOAuthClient =
     app.idpClientId && app.idpClientName && app.idpClientSecret;
@@ -39,7 +38,7 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
           { label: app.name },
         ]}
       />
-      {!appHasOAuthClient && !subscriptions.length && subscriptionsError && (
+      {!appHasOAuthClient && subscriptionsError && (
         <EmptyData
           topicMessageOverride="App details unavailable."
           message="Only admins may view app subscription data."
@@ -50,7 +49,7 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
         <Loader />
       ) : // TODO: Figure out view for when the user isn't an admin. Currently just hides the section.
       !!subscriptionsError ? null : (
-        <ApiSubscriptionsSection app={app} subscriptions={subscriptions} />
+        <ApiSubscriptionsSection app={app} subscriptions={subscriptions!} />
       )}
     </PageContainer>
   );

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -39,7 +39,7 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
           { label: app.name },
         ]}
       />
-      {!appHasOAuthClient && !subscriptions.length && (
+      {!appHasOAuthClient && !subscriptions.length && subscriptionsError && (
         <EmptyData
           topicMessageOverride="App details unavailable."
           message="Only admins may view app subscription data."

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -1,4 +1,4 @@
-import { Loader } from "@mantine/core";
+import { Box, Flex, Loader } from "@mantine/core";
 import { di } from "react-magnetic-di";
 import { App } from "../../../Apis/api-types";
 import { useListSubscriptionsForApp } from "../../../Apis/hooks";
@@ -16,6 +16,10 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
   const subscriptionsError =
     subscriptions !== undefined && "message" in subscriptions;
 
+  // Mock data for testing
+  // app.idpClientId = "4df81266-f855-466d-8ded-699056780850";
+  // app.idpClientName = "test-idp";
+  // app.idpClientSecret = "hidden";
   const appHasOAuthClient =
     app.idpClientId && app.idpClientName && app.idpClientSecret;
 
@@ -44,13 +48,17 @@ const AppDetailsPageContent = ({ app }: { app: App }) => {
           message="Only admins may view app subscription data."
         />
       )}
-      {appHasOAuthClient && <AppAuthenticationSection app={app} />}
-      {isLoadingSubscriptions ? (
-        <Loader />
-      ) : // TODO: Figure out view for when the user isn't an admin. Currently just hides the section.
-      !!subscriptionsError ? null : (
-        <ApiSubscriptionsSection app={app} subscriptions={subscriptions!} />
-      )}
+      <Box px={30}>
+        <Flex gap={"30px"} direction={"column"}>
+          {appHasOAuthClient && <AppAuthenticationSection app={app} />}
+          {isLoadingSubscriptions ? (
+            <Loader />
+          ) : // TODO: Figure out view for when the user isn't an admin. Currently just hides the section.
+          !!subscriptionsError ? null : (
+            <ApiSubscriptionsSection app={app} subscriptions={subscriptions!} />
+          )}
+        </Flex>
+      </Box>
     </PageContainer>
   );
 };

--- a/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
@@ -18,7 +18,15 @@ const AppAuthenticationSection = ({ app }: { app: App }) => {
             <DetailsPageStyles.OAuthClientId>
               {app.idpClientId}
             </DetailsPageStyles.OAuthClientId>
+            {/*
+            // Designs show this "hidden" field, but we have the value.
+            // TODO: Figure out what to show here.
             <DataPairPill pairKey={"Client Secret"} value={"hidden"} />
+            */}
+            <DataPairPill
+              pairKey={"Client Secret"}
+              value={app.idpClientSecret}
+            />
           </DetailsPageStyles.OAuthClientRow>
         </Box>
       </GridCardStyles.GridCard>

--- a/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
@@ -5,11 +5,6 @@ import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { DataPairPill } from "../../../Common/DataPairPill";
 
 const AppAuthenticationSection = ({ app }: { app: App }) => {
-  const hasOAuthClient =
-    app.idpClientId && app.idpClientName && app.idpClientSecret;
-  if (!hasOAuthClient) {
-    return null;
-  }
   return (
     <DetailsPageStyles.Section>
       <DetailsPageStyles.Title>Authentication</DetailsPageStyles.Title>

--- a/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
@@ -1,0 +1,5 @@
+const AppAuthenticationSection = () => {
+  return <div>AppAuthenticationSection</div>;
+};
+
+export default AppAuthenticationSection;

--- a/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/AuthenticationSection/AppAuthenticationSection.tsx
@@ -1,5 +1,34 @@
-const AppAuthenticationSection = () => {
-  return <div>AppAuthenticationSection</div>;
+import { Box } from "@mantine/core";
+import { App } from "../../../../Apis/api-types";
+import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
+import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
+import { DataPairPill } from "../../../Common/DataPairPill";
+
+const AppAuthenticationSection = ({ app }: { app: App }) => {
+  const hasOAuthClient =
+    app.idpClientId && app.idpClientName && app.idpClientSecret;
+  if (!hasOAuthClient) {
+    return null;
+  }
+  return (
+    <DetailsPageStyles.Section>
+      <DetailsPageStyles.Title>Authentication</DetailsPageStyles.Title>
+      <GridCardStyles.GridCard whiteBg>
+        <Box px={"20px"} py={"25px"}>
+          <DetailsPageStyles.CardTitleSmall>
+            OAuth Client
+          </DetailsPageStyles.CardTitleSmall>
+          <DetailsPageStyles.OAuthClientRow>
+            <span>Client ID:</span>
+            <DetailsPageStyles.OAuthClientId>
+              {app.idpClientId}
+            </DetailsPageStyles.OAuthClientId>
+            <DataPairPill pairKey={"Client Secret"} value={"hidden"} />
+          </DetailsPageStyles.OAuthClientRow>
+        </Box>
+      </GridCardStyles.GridCard>
+    </DetailsPageStyles.Section>
+  );
 };
 
 export default AppAuthenticationSection;

--- a/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
@@ -14,6 +14,13 @@ import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
 import { Button } from "../../../Common/Button";
 import { Loading } from "../../../Common/Loading";
 
+/**
+ * This modal is used to add `App -> API Product` subscriptions and is reusable in different contexts.
+ *
+ *   - Creating a subscription requires an App ID and API Product ID.
+ *   - If `app` is supplied, the app selection won't be shown since it will use the supplied `app.id`.
+ *   - Similarly, if `apiProduct` is supplied, the API Product selection won't be shown since it will use the supplied `apiProduct.id`.
+ */
 const NewSubscriptionModal = ({
   opened,
   onClose,

--- a/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
@@ -1,0 +1,182 @@
+import { CloseButton, Flex, Loader, Select } from "@mantine/core";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { di } from "react-magnetic-di";
+import { ApiProductSummary, App } from "../../../../Apis/api-types";
+import {
+  useCreateAppMutation,
+  useCreateSubscriptionMutation,
+  useListApiProducts,
+  useListAppsForTeams,
+  useListTeams,
+} from "../../../../Apis/hooks";
+import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Common/Button";
+import { Loading } from "../../../Common/Loading";
+
+const NewSubscriptionModal = ({
+  opened,
+  onClose,
+  app,
+  apiProduct,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  app?: App;
+  apiProduct?: ApiProductSummary;
+}) => {
+  di(useListTeams, useCreateAppMutation);
+
+  //
+  //  Form state
+  //
+  const [formApiProductId, setFormApiProductId] = useState(
+    apiProduct?.id ?? ""
+  );
+  const [formAppId, setFormAppId] = useState(app?.id ?? "");
+
+  const formRef = useRef<HTMLFormElement>(null);
+  const isFormDisabled = !formRef.current?.checkValidity();
+  const resetForm = () => {
+    setFormApiProductId("");
+    setFormAppId("");
+  };
+
+  //
+  //  Get App and APIProduct selection options
+  //
+  const { isLoading: isLoadingTeams, data: teams } = useListTeams();
+  const { isLoading: isLoadingApps, data: appsForTeams } = useListAppsForTeams(
+    teams ?? []
+  );
+  const apps = useMemo(() => {
+    return appsForTeams?.flat() ?? [];
+  }, [appsForTeams]);
+
+  //
+  //  Form Submit logic
+  //
+  const { isLoading: isLoadingApiProducts, data: apiProducts } =
+    useListApiProducts();
+  const { trigger: createSubscription } =
+    useCreateSubscriptionMutation(formAppId);
+
+  const onSubmit = async (e?: FormEvent) => {
+    e?.preventDefault();
+    // Do HTML form validation.
+    formRef.current?.reportValidity();
+    if (isFormDisabled) {
+      return;
+    }
+    await toast.promise(
+      createSubscription({ apiProductId: formApiProductId }),
+      {
+        error: "There was an error creating the subscription.",
+        loading: "Creating the subscription...",
+        success: "Created the subscription!",
+      }
+    );
+    onClose();
+  };
+
+  // Reset the form on close.
+  useEffect(() => {
+    if (!opened) resetForm();
+  }, [opened]);
+
+  //
+  // Render
+  //
+  return (
+    <FormModalStyles.CustomModal
+      onClose={onClose}
+      opened={opened}
+      size={"800px"}
+    >
+      <FormModalStyles.HeaderContainer>
+        <div>
+          <FormModalStyles.Title>
+            Create a New Subscription
+          </FormModalStyles.Title>
+          <FormModalStyles.Subtitle>
+            Create a new Subscription.
+          </FormModalStyles.Subtitle>
+        </div>
+        <CloseButton title="Close modal" size={"30px"} />
+      </FormModalStyles.HeaderContainer>
+      <FormModalStyles.HorizLine />
+      {isLoadingTeams || teams === undefined ? (
+        <Loading />
+      ) : (
+        <FormModalStyles.BodyContainerForm ref={formRef} onSubmit={onSubmit}>
+          {!app &&
+            (isLoadingApps || !apps ? (
+              <Loader />
+            ) : (
+              <FormModalStyles.InputContainer>
+                <label htmlFor="app-select">App</label>
+                <Select
+                  id="app-select"
+                  // This className="" is intentional and removes the antd select dropdown classname.
+                  className=""
+                  value={formAppId}
+                  onChange={(value) => {
+                    setFormAppId(value ?? "");
+                  }}
+                  data={[
+                    {
+                      value: "",
+                      label: "Select an App",
+                      disabled: true,
+                    },
+                    ...apps.map((app) => ({
+                      value: app.id,
+                      label: app.name,
+                    })),
+                  ]}
+                />
+              </FormModalStyles.InputContainer>
+            ))}
+          {!apiProduct &&
+            (isLoadingApiProducts || !apiProducts ? (
+              <Loader />
+            ) : (
+              <FormModalStyles.InputContainer>
+                <label htmlFor="api-product-select">API Product</label>
+                <Select
+                  id="api-product-select"
+                  // This className="" is intentional and removes the antd select dropdown classname.
+                  className=""
+                  value={formApiProductId}
+                  onChange={(value) => {
+                    setFormApiProductId(value ?? "");
+                  }}
+                  data={[
+                    {
+                      value: "",
+                      label: "Select an API Product",
+                      disabled: true,
+                    },
+                    ...apiProducts.map((ap) => ({
+                      value: ap.id,
+                      label: ap.name,
+                    })),
+                  ]}
+                />
+              </FormModalStyles.InputContainer>
+            ))}
+          <Flex justify={"flex-end"} gap="20px">
+            <Button className="outline" onClick={onClose} type="button">
+              Cancel
+            </Button>
+            <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">
+              Create Subscription
+            </Button>
+          </Flex>
+        </FormModalStyles.BodyContainerForm>
+      )}
+    </FormModalStyles.CustomModal>
+  );
+};
+
+export default NewSubscriptionModal;

--- a/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
@@ -109,7 +109,7 @@ const NewSubscriptionModal = ({
             Create a new Subscription.
           </FormModalStyles.Subtitle>
         </div>
-        <CloseButton title="Close modal" size={"30px"} />
+        <CloseButton onClick={onClose} title="Close modal" size={"30px"} />
       </FormModalStyles.HeaderContainer>
       <FormModalStyles.HorizLine />
       {isLoadingTeams || teams === undefined ? (

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -31,7 +31,7 @@ export function AppSummaryGridCard({ app }: { app: AppWithTeam }) {
           <img src={defaultCardImage} alt="" role="banner" />
         </div>
         <Box px={"20px"}>
-          <CardStyles.Title>{app.name}</CardStyles.Title>
+          <CardStyles.TitleLarge>{app.name}</CardStyles.TitleLarge>
           <CardStyles.Description>{app.description}</CardStyles.Description>
         </Box>
       </div>

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryListCard.tsx
@@ -18,7 +18,7 @@ export function AppSummaryListCard({ app }: { app: AppWithTeam }) {
             <Icon.WrenchGear className="colorIt" />
           </div>
           <Box p={"30px"}>
-            <CardStyles.Title>{app.name}</CardStyles.Title>
+            <CardStyles.TitleLarge>{app.name}</CardStyles.TitleLarge>
             <CardStyles.Description>{app.description}</CardStyles.Description>
           </Box>
         </div>

--- a/projects/ui/src/Components/Common/EmptyData.tsx
+++ b/projects/ui/src/Components/Common/EmptyData.tsx
@@ -115,13 +115,19 @@ const LoadingContainer = styled.div(
   `
 );
 
-export function EmptyData({
-  topic,
-  message,
-}: {
-  topic: string;
-  message?: string;
-}) {
+export function EmptyData(
+  props:
+    | (
+        | {
+            topic: string;
+          }
+        | {
+            topicMessageOverride: string;
+          }
+      ) & {
+        message?: string;
+      }
+) {
   return (
     <LoadingContainer aria-hidden="true">
       <div className="emptyCircle">
@@ -132,8 +138,16 @@ export function EmptyData({
           <div className="circle"></div>
         </div>
       </div>
-      <div className="emptyMainMessage">No {topic} results were found</div>
-      {!!message && <div className="emptyDetailsMessage">{message}</div>}
+      {"topicMessageOverride" in props ? (
+        <div className="emptyMainMessage">{props.topicMessageOverride}</div>
+      ) : (
+        <div className="emptyMainMessage">
+          No {props.topic} results were found
+        </div>
+      )}
+      {!!props.message && (
+        <div className="emptyDetailsMessage">{props.message}</div>
+      )}
     </LoadingContainer>
   );
 }

--- a/projects/ui/src/Components/Teams/Details/AppsSection/TeamAppsSection.tsx
+++ b/projects/ui/src/Components/Teams/Details/AppsSection/TeamAppsSection.tsx
@@ -1,0 +1,5 @@
+const TeamAppsSection = () => {
+  return <div>TeamAppsSection</div>;
+};
+
+export default TeamAppsSection;

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPage.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPage.tsx
@@ -1,10 +1,18 @@
 import { di } from "react-magnetic-di";
 import { useParams } from "react-router-dom";
+import { useGetTeamDetails } from "../../../Apis/hooks";
+import { Loading } from "../../Common/Loading";
+import TeamDetailsPageContent from "./TeamDetailsPageContent";
 
 const TeamDetailsPage = () => {
   di(useParams);
   const { teamId } = useParams();
-  return <div>TeamDetailsPage {teamId}</div>;
+  const { isLoading, data: team } = useGetTeamDetails(teamId);
+
+  if (isLoading || !team) {
+    return <Loading />;
+  }
+  return <TeamDetailsPageContent team={team} />;
 };
 
 export default TeamDetailsPage;

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPage.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPage.tsx
@@ -1,0 +1,10 @@
+import { di } from "react-magnetic-di";
+import { useParams } from "react-router-dom";
+
+const TeamDetailsPage = () => {
+  di(useParams);
+  const { teamId } = useParams();
+  return <div>TeamDetailsPage {teamId}</div>;
+};
+
+export default TeamDetailsPage;

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
@@ -1,0 +1,35 @@
+import { Team } from "../../../Apis/api-types";
+import { BannerHeading } from "../../Common/Banner/BannerHeading";
+import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
+import { PageContainer } from "../../Common/PageContainer";
+import TeamAppsSection from "./AppsSection/TeamAppsSection";
+import TeamUsersSection from "./UsersSection/TeamUsersSection";
+
+const TeamDetailsPageContent = ({ team }: { team: Team }) => {
+  return (
+    <PageContainer>
+      <BannerHeading
+        title={
+          <BannerHeadingTitle
+            text={team.name}
+            stylingTweaks={{
+              fontSize: "32px",
+              lineHeight: "36px",
+            }}
+          />
+        }
+        // fullIcon={<Icon.Bug />}
+        description={team.description}
+        breadcrumbItems={[
+          { label: "Home", link: "/" },
+          { label: "Teams", link: "/teams" },
+          { label: team.name },
+        ]}
+      />
+      <TeamAppsSection />
+      <TeamUsersSection />
+    </PageContainer>
+  );
+};
+
+export default TeamDetailsPageContent;

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
@@ -18,7 +18,6 @@ const TeamDetailsPageContent = ({ team }: { team: Team }) => {
             }}
           />
         }
-        // fullIcon={<Icon.Bug />}
         description={team.description}
         breadcrumbItems={[
           { label: "Home", link: "/" },

--- a/projects/ui/src/Components/Teams/Details/UsersSection/TeamUsersSection.tsx
+++ b/projects/ui/src/Components/Teams/Details/UsersSection/TeamUsersSection.tsx
@@ -1,0 +1,5 @@
+const TeamUsersSection = () => {
+  return <div>TeamUsersSection</div>;
+};
+
+export default TeamUsersSection;

--- a/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Teams/PageContent/TeamSummaryCards/TeamSummaryGridCard.tsx
@@ -26,9 +26,7 @@ export function TeamSummaryGridCard({ team }: { team: Team }) {
       <div className="content">
         <Box p={"20px"}>
           <Flex direction={"column"} align={"flex-start"} gap={"5px"}>
-            <SubscriptionInfoCardStyles.CardTitleSmall>
-              {team.name}
-            </SubscriptionInfoCardStyles.CardTitleSmall>
+            <CardStyles.TitleSmall bold>{team.name}</CardStyles.TitleSmall>
             <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
               <Flex align={"center"} justify={"flex-start"} gap={"8px"}>
                 <Icon.AppIcon width={20} />

--- a/projects/ui/src/Styles/shared/Card.style.tsx
+++ b/projects/ui/src/Styles/shared/Card.style.tsx
@@ -3,12 +3,38 @@ import styled from "@emotion/styled";
 
 // TODO: Consolidate styles from ./GridCard.style.tsx and ListCard.style.tsx here, refactor, and reduce the amount of styles.
 export namespace CardStyles {
-  export const Title = styled.div`
+  export const TitleLarge = styled.div`
     line-height: 30px;
     font-size: 28px;
     font-weight: 600;
     margin-bottom: 10px;
   `;
+
+  export const TitleMedium = styled.div<{ bold?: boolean }>(
+    ({ bold }) => css`
+      font-size: 1.5rem;
+      font-weight: bold;
+      margin-bottom: 2px;
+      ${bold
+        ? css`
+            font-weight: 500;
+          `
+        : ""}
+    `
+  );
+
+  export const TitleSmall = styled.div<{ bold?: boolean }>(
+    ({ bold }) => css`
+      font-size: 1.25rem;
+      margin-bottom: 2px;
+      text-align: left;
+      ${bold
+        ? css`
+            font-weight: 500;
+          `
+        : ""}
+    `
+  );
 
   export const Description = styled.div(
     ({ theme }) => css`

--- a/projects/ui/src/Styles/shared/DetailsPageStyles.tsx
+++ b/projects/ui/src/Styles/shared/DetailsPageStyles.tsx
@@ -1,0 +1,37 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Flex } from "@mantine/core";
+
+export namespace DetailsPageStyles {
+  export const Section = styled(Flex)`
+    flex-direction: column;
+    gap: 30px;
+  `;
+
+  export const Title = styled.h2`
+    font-size: 1.4rem;
+    font-weight: 500;
+    margin-bottom: -15px;
+  `;
+
+  export const CardTitleSmall = styled.div`
+    font-size: 1.2rem;
+    margin-bottom: 5px;
+    text-align: left;
+    font-weight: 500;
+  `;
+
+  export const OAuthClientRow = styled(Flex)`
+    font-size: 0.9rem;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 10px;
+  `;
+
+  export const OAuthClientId = styled.span(
+    ({ theme }) => css`
+      color: ${theme.augustGrey};
+      margin-right: 5px;
+    `
+  );
+}

--- a/projects/ui/src/Utility/link-builders.ts
+++ b/projects/ui/src/Utility/link-builders.ts
@@ -9,9 +9,9 @@ export function getApiDetailsLink<
 }
 
 export function getAppDetailsLink(app: App) {
-  return `/app-details/${app.id}`;
+  return `/apps/${app.id}`;
 }
 
 export function getTeamDetailsLink(team: Team) {
-  return `/team-details/${team.id}`;
+  return `/teams/${team.id}`;
 }


### PR DESCRIPTION
## Overview
This PR adds the app details page, and:
  - Adds a modal for adding subscriptions.
  - Adds the OAuth section if `idpClientId`, `idpClientSecret`, and `idpClientName` are present.
  - Adds the empty state for when no OAuth client data or subscriptions are present.

## Screenshots
With mock (`app.idpClientId`, `app.idpClientSecret`, and `app.idpClientName`) data:
<img width="1261" alt="Screenshot 2024-03-08 at 2 26 03 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/26668d1e-785d-4a98-a45d-e4c23b9540a3">

Adding a subscription modal:
<img width="1242" alt="Screenshot 2024-03-08 at 2 13 11 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/9dcde20e-417a-47ba-ba67-6b9b4db500ce">

App details with no subscriptions or OAuth information:
<img width="1261" alt="Screenshot 2024-03-08 at 2 27 43 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/5678cc59-db6c-4964-a68e-b58c537bc609">

