### PR TITLE
Allow editing teams and app names and descriptions

### DIFF
--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -297,7 +297,6 @@ export function useUpdateAppMutation() {
   const { mutate } = useSWRConfig();
   const updateApp = async (_url: string, { arg }: UpdateAppParams) => {
     const { appId, appTeamId, appName, appDescription } = arg;
-    // Update the app
     await fetchJSON(`/apps/${appId}`, {
       method: "PUT",
       headers: getLatestAuthHeaders(latestAccessToken),
@@ -324,7 +323,6 @@ export function useUpdateTeamMutation() {
   const { mutate } = useSWRConfig();
   const updateTeam = async (_url: string, { arg }: UpdateTeamParams) => {
     const { teamId, teamName, teamDescription } = arg;
-    // Update the app
     await fetchJSON(`/teams/${teamId}`, {
       method: "PUT",
       headers: getLatestAuthHeaders(latestAccessToken),

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -283,6 +283,60 @@ export function useCreateAppMutation(teamId: string | undefined) {
 }
 
 // ------------------------ //
+// Update App
+
+type UpdateAppParams = MutationWithArgs<{
+  appId: string;
+  appTeamId: string;
+  appName: string;
+  appDescription: string;
+}>;
+
+export function useUpdateAppMutation() {
+  const { latestAccessToken } = useContext(PortalAuthContext);
+  const { mutate } = useSWRConfig();
+  const updateApp = async (_url: string, { arg }: UpdateAppParams) => {
+    const { appId, appTeamId, appName, appDescription } = arg;
+    // Update the app
+    await fetchJSON(`/apps/${appId}`, {
+      method: "PUT",
+      headers: getLatestAuthHeaders(latestAccessToken),
+      body: JSON.stringify({ name: appName, description: appDescription }),
+    });
+    mutate(TEAM_APPS_SWR_KEY);
+    mutate(`/teams/${appTeamId}/apps`);
+    mutate(`/apps/${appId}`);
+  };
+  return useSWRMutation("update-app", updateApp);
+}
+
+// ------------------------ //
+// Update Team
+
+type UpdateTeamParams = MutationWithArgs<{
+  teamId: string;
+  teamName: string;
+  teamDescription: string;
+}>;
+
+export function useUpdateTeamMutation() {
+  const { latestAccessToken } = useContext(PortalAuthContext);
+  const { mutate } = useSWRConfig();
+  const updateTeam = async (_url: string, { arg }: UpdateTeamParams) => {
+    const { teamId, teamName, teamDescription } = arg;
+    // Update the app
+    await fetchJSON(`/teams/${teamId}`, {
+      method: "PUT",
+      headers: getLatestAuthHeaders(latestAccessToken),
+      body: JSON.stringify({ name: teamName, description: teamDescription }),
+    });
+    mutate(TEAMS_SWR_KEY);
+    mutate(`/teams/${teamId}`);
+  };
+  return useSWRMutation("update-team", updateTeam);
+}
+
+// ------------------------ //
 // Create App and Subscription
 
 type CreateAppAndSubscriptionParams = MutationWithArgs<{

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -7,6 +7,7 @@ import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
 import { PageContainer } from "../../Common/PageContainer";
 import AppApiSubscriptionsSection from "./ApiSubscriptionsSection/AppApiSubscriptionsSection";
 import AppAuthenticationSection from "./AuthenticationSection/AppAuthenticationSection";
+import EditAppButtonWithModal from "./EditAppButtonWithModal";
 
 export const AppDetailsPageContent = ({ app }: { app: App }) => {
   di(useListSubscriptionsForApp);
@@ -24,13 +25,13 @@ export const AppDetailsPageContent = ({ app }: { app: App }) => {
     <PageContainer>
       <BannerHeading
         title={
-          // TODO: Add edit button here
           <BannerHeadingTitle
             text={app.name}
             stylingTweaks={{
               fontSize: "32px",
               lineHeight: "36px",
             }}
+            additionalInfo={<EditAppButtonWithModal app={app} />}
           />
         }
         description={app.description}

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -24,6 +24,7 @@ export const AppDetailsPageContent = ({ app }: { app: App }) => {
     <PageContainer>
       <BannerHeading
         title={
+          // TODO: Add edit button here
           <BannerHeadingTitle
             text={app.name}
             stylingTweaks={{

--- a/projects/ui/src/Components/Apps/Details/EditAppButtonWithModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/EditAppButtonWithModal.tsx
@@ -1,0 +1,28 @@
+import { Button, Tooltip } from "@mantine/core";
+import { useState } from "react";
+import { App } from "../../../Apis/api-types";
+import { Icon } from "../../../Assets/Icons";
+import { DetailsPageStyles } from "../../../Styles/shared/DetailsPageStyles";
+import { EditAppModal } from "./Modals/EditAppModal";
+
+const EditAppButtonWithModal = ({ app }: { app: App }) => {
+  const [showEditModal, setShowEditModal] = useState(false);
+  return (
+    <>
+      <DetailsPageStyles.EditButtonAndTooltipContainer>
+        <Tooltip label="Edit App">
+          <Button variant="subtle" onClick={() => setShowEditModal(true)}>
+            <Icon.Pencil />
+          </Button>
+        </Tooltip>
+      </DetailsPageStyles.EditButtonAndTooltipContainer>
+      <EditAppModal
+        app={app}
+        opened={showEditModal}
+        onClose={() => setShowEditModal(false)}
+      />
+    </>
+  );
+};
+
+export default EditAppButtonWithModal;

--- a/projects/ui/src/Components/Apps/Details/Modals/EditAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/EditAppModal.tsx
@@ -1,0 +1,121 @@
+import { CloseButton, Flex, Input } from "@mantine/core";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { App } from "../../../../Apis/api-types";
+import { useUpdateAppMutation } from "../../../../Apis/hooks";
+import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Common/Button";
+
+export const EditAppModal = ({
+  opened,
+  onClose,
+  app,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  app: App;
+}) => {
+  //
+  // Form Fields
+  //
+  const [appName, setAppName] = useState(app.name);
+  const [appDescription, setAppDescription] = useState(app.description);
+
+  //
+  // Form
+  //
+  const formRef = useRef<HTMLFormElement>(null);
+  const isFormDisabled = !appName || !appDescription;
+  useEffect(() => {
+    // The form resets here when `open` or the default fields change.
+    setAppName(app.name);
+    setAppDescription(app.description);
+  }, [app, opened]);
+
+  //
+  //  Form Submit
+  //
+  const { trigger: updateApp } = useUpdateAppMutation();
+  const onSubmit = async (e?: FormEvent) => {
+    e?.preventDefault();
+    const isValid = formRef.current?.reportValidity();
+    if (!isValid || isFormDisabled) {
+      return;
+    }
+    await toast.promise(
+      updateApp({
+        appId: app.id,
+        appName,
+        appDescription,
+        appTeamId: app.teamId,
+      }),
+      {
+        error: "There was an error updating the app.",
+        loading: "Updating the app.",
+        success: "Updated the app!",
+      }
+    );
+    onClose();
+  };
+
+  //
+  // Render
+  //
+  return (
+    <FormModalStyles.CustomModal
+      onClose={onClose}
+      opened={opened}
+      size={"800px"}
+    >
+      <FormModalStyles.HeaderContainer>
+        <div>
+          <FormModalStyles.Title>Edit App</FormModalStyles.Title>
+          <FormModalStyles.Subtitle>
+            Edit the title and description for this App.
+          </FormModalStyles.Subtitle>
+        </div>
+        <CloseButton title="Close modal" size={"30px"} onClick={onClose} />
+      </FormModalStyles.HeaderContainer>
+      <FormModalStyles.HorizLine />
+      <FormModalStyles.BodyContainerForm ref={formRef} onSubmit={onSubmit}>
+        <div>
+          <FormModalStyles.FormRow>
+            <label htmlFor="app-name-input">App Name</label>
+            <Input
+              id="app-name-input"
+              required
+              placeholder="App Name"
+              autoComplete="off"
+              value={appName}
+              onChange={(e) => setAppName(e.target.value)}
+            />
+          </FormModalStyles.FormRow>
+          <FormModalStyles.FormRow>
+            <label htmlFor="app-description-input">App Description</label>
+            <Input
+              // This could be a Textarea if newlines exist in the description.
+              // Then we would need to get the text content using a ref
+              // so that newlines are preserved when saved.
+              // <Textarea
+              id="app-description-input"
+              required
+              placeholder="App Description"
+              autoComplete="off"
+              value={appDescription}
+              onChange={(e) => setAppDescription(e.target.value)}
+            />
+          </FormModalStyles.FormRow>
+        </div>
+
+        <Flex justify={"flex-end"} gap="20px">
+          <Button className="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">
+            Update App
+          </Button>
+        </Flex>
+      </FormModalStyles.BodyContainerForm>
+    </FormModalStyles.CustomModal>
+  );
+};

--- a/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
@@ -1,4 +1,3 @@
-import styled from "@emotion/styled";
 import { Box, CloseButton, Flex, Loader, Select } from "@mantine/core";
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -23,10 +22,6 @@ import { Button } from "../../../Common/Button";
 import { Loading } from "../../../Common/Loading";
 import ToggleAddButton from "../../../Common/ToggleAddButton";
 import CreateNewAppFormContents from "../../Modals/CreateNewAppFormContents";
-
-const StyledSectionTitle = styled.div`
-  font-size: 1.5rem;
-`;
 
 /**
  * This modal is used to add `App -> API Product` subscriptions and is reusable in different contexts.
@@ -165,10 +160,10 @@ const NewSubscriptionModal = ({
               <FormModalStyles.InputContainer>
                 <Box mb="10px">
                   <Flex justify={"space-between"} align={"center"}>
-                    <StyledSectionTitle>
+                    <FormModalStyles.SectionTitle>
                       {isShowingAddAppSubSection ? "Create a New" : "Choose"}{" "}
                       App
-                    </StyledSectionTitle>
+                    </FormModalStyles.SectionTitle>
                     <ToggleAddButton
                       topicUpperCase="APP"
                       isAdding={isShowingAddAppSubSection}

--- a/projects/ui/src/Components/Apps/Modals/CreateNewAppFormContents.tsx
+++ b/projects/ui/src/Components/Apps/Modals/CreateNewAppFormContents.tsx
@@ -1,27 +1,8 @@
-import styled from "@emotion/styled";
 import { Input, Select } from "@mantine/core";
 import { useEffect } from "react";
 import { Team } from "../../../Apis/api-types";
+import { FormModalStyles } from "../../../Styles/shared/FormModalStyles";
 import { Accordion } from "../../Common/Accordion";
-
-const StyledFormRow = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-start;
-  padding-bottom: 15px;
-  label {
-    width: 100%;
-    padding: 0px;
-    font-size: 1.3rem;
-    margin-bottom: 10px;
-    text-align: left;
-  }
-  .mantine-Input-wrapper,
-  .mantine-InputWrapper-root {
-    flex-grow: 1;
-  }
-`;
 
 export interface CreateNewAppFormFields {
   appName: string;
@@ -67,7 +48,7 @@ const CreateNewAppFormContents = ({
   //
   return (
     <div>
-      <StyledFormRow>
+      <FormModalStyles.FormRow>
         <label htmlFor="app-team-select">App Team</label>
         <Select
           id="app-team-select"
@@ -90,9 +71,9 @@ const CreateNewAppFormContents = ({
             })),
           ]}
         />
-      </StyledFormRow>
+      </FormModalStyles.FormRow>
       <Accordion open={!!appTeamId}>
-        <StyledFormRow>
+        <FormModalStyles.FormRow>
           <label htmlFor="app-name-input">App Name</label>
           <Input
             id="app-name-input"
@@ -103,8 +84,8 @@ const CreateNewAppFormContents = ({
             value={appName}
             onChange={(e) => setAppName(e.target.value)}
           />
-        </StyledFormRow>
-        <StyledFormRow>
+        </FormModalStyles.FormRow>
+        <FormModalStyles.FormRow>
           <label htmlFor="app-description-input">App Description</label>
           <Input
             // This could be a Textarea if newlines exist in the description.
@@ -119,7 +100,7 @@ const CreateNewAppFormContents = ({
             value={appDescription}
             onChange={(e) => setAppDescription(e.target.value)}
           />
-        </StyledFormRow>
+        </FormModalStyles.FormRow>
       </Accordion>
     </div>
   );

--- a/projects/ui/src/Components/Common/Banner/BannerHeading.tsx
+++ b/projects/ui/src/Components/Common/Banner/BannerHeading.tsx
@@ -40,6 +40,7 @@ const BannerContent = styled.div(
 
 const BannerCardRightContent = styled.div(
   ({ theme }) => css`
+    width: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/projects/ui/src/Components/Teams/Details/EditTeamButtonWithModal.tsx
+++ b/projects/ui/src/Components/Teams/Details/EditTeamButtonWithModal.tsx
@@ -1,0 +1,28 @@
+import { Button, Tooltip } from "@mantine/core";
+import { useState } from "react";
+import { Team } from "../../../Apis/api-types";
+import { Icon } from "../../../Assets/Icons";
+import { DetailsPageStyles } from "../../../Styles/shared/DetailsPageStyles";
+import { EditTeamModal } from "./Modals/EditTeamModal";
+
+const EditTeamButtonWithModal = ({ team }: { team: Team }) => {
+  const [showEditModal, setShowEditModal] = useState(false);
+  return (
+    <>
+      <DetailsPageStyles.EditButtonAndTooltipContainer>
+        <Tooltip label="Edit Team">
+          <Button variant="subtle" onClick={() => setShowEditModal(true)}>
+            <Icon.Pencil />
+          </Button>
+        </Tooltip>
+      </DetailsPageStyles.EditButtonAndTooltipContainer>
+      <EditTeamModal
+        team={team}
+        opened={showEditModal}
+        onClose={() => setShowEditModal(false)}
+      />
+    </>
+  );
+};
+
+export default EditTeamButtonWithModal;

--- a/projects/ui/src/Components/Teams/Details/Modals/EditTeamModal.tsx
+++ b/projects/ui/src/Components/Teams/Details/Modals/EditTeamModal.tsx
@@ -1,0 +1,120 @@
+import { CloseButton, Flex, Input } from "@mantine/core";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { Team } from "../../../../Apis/api-types";
+import { useUpdateTeamMutation } from "../../../../Apis/hooks";
+import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Common/Button";
+
+export const EditTeamModal = ({
+  opened,
+  onClose,
+  team,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  team: Team;
+}) => {
+  //
+  // Form Fields
+  //
+  const [teamName, setTeamName] = useState(team.name);
+  const [teamDescription, setTeamDescription] = useState(team.description);
+
+  //
+  // Form
+  //
+  const formRef = useRef<HTMLFormElement>(null);
+  const isFormDisabled = !teamName || !teamDescription;
+  useEffect(() => {
+    // The form resets here when `open` or the default fields change.
+    setTeamName(team.name);
+    setTeamDescription(team.description);
+  }, [team, opened]);
+
+  //
+  //  Form Submit
+  //
+  const { trigger: updateTeam } = useUpdateTeamMutation();
+  const onSubmit = async (e?: FormEvent) => {
+    e?.preventDefault();
+    const isValid = formRef.current?.reportValidity();
+    if (!isValid || isFormDisabled) {
+      return;
+    }
+    await toast.promise(
+      updateTeam({
+        teamId: team.id,
+        teamName,
+        teamDescription,
+      }),
+      {
+        error: "There was an error updating the team.",
+        loading: "Updating the team.",
+        success: "Updated the team!",
+      }
+    );
+    onClose();
+  };
+
+  //
+  // Render
+  //
+  return (
+    <FormModalStyles.CustomModal
+      onClose={onClose}
+      opened={opened}
+      size={"800px"}
+    >
+      <FormModalStyles.HeaderContainer>
+        <div>
+          <FormModalStyles.Title>Edit Team</FormModalStyles.Title>
+          <FormModalStyles.Subtitle>
+            Edit the title and description for this Team.
+          </FormModalStyles.Subtitle>
+        </div>
+        <CloseButton title="Close modal" size={"30px"} onClick={onClose} />
+      </FormModalStyles.HeaderContainer>
+      <FormModalStyles.HorizLine />
+      <FormModalStyles.BodyContainerForm ref={formRef} onSubmit={onSubmit}>
+        <div>
+          <FormModalStyles.FormRow>
+            <label htmlFor="team-name-input">Team Name</label>
+            <Input
+              id="team-name-input"
+              required
+              placeholder="Team Name"
+              autoComplete="off"
+              value={teamName}
+              onChange={(e) => setTeamName(e.target.value)}
+            />
+          </FormModalStyles.FormRow>
+          <FormModalStyles.FormRow>
+            <label htmlFor="team-description-input">Team Description</label>
+            <Input
+              // This could be a Textarea if newlines exist in the description.
+              // Then we would need to get the text content using a ref
+              // so that newlines are preserved when saved.
+              // <Textarea
+              id="team-description-input"
+              required
+              placeholder="Team Description"
+              autoComplete="off"
+              value={teamDescription}
+              onChange={(e) => setTeamDescription(e.target.value)}
+            />
+          </FormModalStyles.FormRow>
+        </div>
+
+        <Flex justify={"flex-end"} gap="20px">
+          <Button className="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">
+            Update Team
+          </Button>
+        </Flex>
+      </FormModalStyles.BodyContainerForm>
+    </FormModalStyles.CustomModal>
+  );
+};

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
@@ -4,6 +4,7 @@ import { BannerHeading } from "../../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
 import { PageContainer } from "../../Common/PageContainer";
 import TeamAppsSection from "./AppsSection/TeamAppsSection";
+import EditTeamButtonWithModal from "./EditTeamButtonWithModal";
 import TeamUsersSection from "./UsersSection/TeamUsersSection";
 
 const TeamDetailsPageContent = ({ team }: { team: Team }) => {
@@ -17,6 +18,7 @@ const TeamDetailsPageContent = ({ team }: { team: Team }) => {
               fontSize: "32px",
               lineHeight: "36px",
             }}
+            additionalInfo={<EditTeamButtonWithModal team={team} />}
           />
         }
         description={team.description}

--- a/projects/ui/src/Styles/shared/DetailsPageStyles.tsx
+++ b/projects/ui/src/Styles/shared/DetailsPageStyles.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Flex } from "@mantine/core";
+import { svgColorReplace } from "../utils";
 
 export namespace DetailsPageStyles {
   export const Section = styled(Flex)`
@@ -45,6 +46,26 @@ export namespace DetailsPageStyles {
         }
         flex-grow: 1;
       }
+    `
+  );
+
+  export const EditButtonAndTooltipContainer = styled.div(
+    ({ theme }) => css`
+      display: flex;
+      flex-grow: 1;
+      justify-content: flex-end;
+      align-items: center;
+      height: 100%;
+      button {
+        padding: 10px 0px;
+        width: unset;
+        min-width: unset;
+      }
+      svg {
+        /* width: 20px; */
+        height: 100%;
+      }
+      ${svgColorReplace(theme.augustGrey)}
     `
   );
 }

--- a/projects/ui/src/Styles/shared/FormModalStyles.tsx
+++ b/projects/ui/src/Styles/shared/FormModalStyles.tsx
@@ -48,7 +48,7 @@ export namespace FormModalStyles {
 
   export const Title = styled.div`
     font-size: 1.7rem;
-    padding-bottom: 3px;
+    padding-bottom: 10px;
   `;
 
   export const Subtitle = styled.div`
@@ -80,4 +80,27 @@ export namespace FormModalStyles {
         : ""}
     `
   );
+
+  export const SectionTitle = styled.div`
+    font-size: 1.5rem;
+  `;
+
+  export const FormRow = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    padding-bottom: 15px;
+    label {
+      width: 100%;
+      padding: 0px;
+      font-size: 1.3rem;
+      margin-bottom: 10px;
+      text-align: left;
+    }
+    .mantine-Input-wrapper,
+    .mantine-InputWrapper-root {
+      flex-grow: 1;
+    }
+  `;
 }


### PR DESCRIPTION
- Adds an edit button for apps and teams details pages that opens a modal where the user can edit their title (and for apps, their description).
  - Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/15782


This is a video where I edit the title and description of teams and apps.

https://github.com/solo-io/dev-portal-starter/assets/4720646/c75a5c27-8d19-4287-99e7-c2b5214d9631

