### PR TITLE
Color + button refactoring and some feedback

### DIFF
--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -80,6 +80,7 @@ export type Member = {
 export enum SubscriptionStatus {
   APPROVED = "approved",
   PENDING = "pending",
+  REJECTED = "rejected",
 }
 export type Subscription = {
   apiProductId: string;

--- a/projects/ui/src/Components/ApiProductDetails/SchemaTab/ApiSchemaDisplay.style.tsx
+++ b/projects/ui/src/Components/ApiProductDetails/SchemaTab/ApiSchemaDisplay.style.tsx
@@ -1,0 +1,134 @@
+import { Theme, css } from "@emotion/react";
+
+export const makeStyledButtonCSS = (theme: Theme) => css`
+  // A consistent button for general use.
+  //  We've avoided being opionated here about "display"
+  //    type here, but one could certainly follow "inline-..." conventions.
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: currentColor;
+  cursor: pointer;
+
+  border-radius: 2px;
+  height: 40px;
+  min-width: 90px;
+  padding: 0 22px;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  transition: background-color 0.1s linear;
+
+  //
+  // Primary states
+  //
+  border: 1px solid ${theme.januaryGrey};
+  background-color: ${theme.lakeBlue};
+  &:hover {
+    background-color: ${theme.primaryLight10};
+  }
+  &:active {
+    background-color: ${theme.primaryLight20};
+  }
+
+  //
+  // Pale states
+  //
+  &.paleButton {
+    border-color: ${theme.primary};
+    background-color: white;
+    color: ${theme.primary};
+    &:hover {
+      background-color: ${theme.primaryLight10};
+      border-color: ${theme.primaryLight10};
+      color: white;
+    }
+    &:active {
+      background-color: ${theme.primaryLight20};
+      border-color: ${theme.primaryLight20};
+      color: white;
+    }
+  }
+
+  &.smallButton {
+    height: 26px;
+    line-height: 26px;
+  }
+
+  //
+  // Just text states
+  //
+  &.justText {
+    display: inline;
+    height: auto;
+    line-height: inherit;
+    border: none;
+    background-color: transparent;
+    font-size: inherit;
+    padding: 0;
+
+    color: ${theme.primary};
+    font-weight: 500;
+    &:hover {
+      color: ${theme.primaryLight10};
+    }
+    &:active {
+      color: ${theme.primaryLight20};
+    }
+  }
+
+  //
+  // Success states
+  //
+  &.success {
+    background-color: ${theme.midGreen};
+    &:hover {
+      background-color: ${theme.midGreenLight10};
+    }
+    &:active {
+      background-color: ${theme.midGreenLight20};
+    }
+  }
+
+  //
+  // Outline states
+  //
+  &.outline {
+    color: ${theme.lakeBlue};
+    border: 1px solid ${theme.lakeBlue};
+    background-color: white;
+    &:hover {
+      color: white;
+      background-color: ${theme.primaryLight10};
+      border: none;
+    }
+    &:active {
+      color: white;
+      background-color: ${theme.primaryLight20};
+      border: none;
+    }
+  }
+
+  //
+  // Error states
+  //
+  &.error {
+    background-color: ${theme.pumpkinOrange};
+    &:hover {
+      background-color: ${theme.pumpkinOrangeLight10};
+    }
+    &:active {
+      background-color: ${theme.pumpkinOrangeLight20};
+    }
+  }
+
+  //
+  // Disabled states
+  //
+  &.disabled,
+  &.disabled:hover,
+  &.disabled:active {
+    cursor: not-allowed;
+    background-color: ${theme.augustGrey};
+  }
+`;

--- a/projects/ui/src/Components/ApiProductDetails/SchemaTab/ApiSchemaDisplay.tsx
+++ b/projects/ui/src/Components/ApiProductDetails/SchemaTab/ApiSchemaDisplay.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@mantine/core";
 import { useState } from "react";
 import { ApiVersionSchema } from "../../../Apis/api-types";
+import { Button } from "../../Common/Button";
 import { ApiProductDetailsPageStyles as Styles } from "../ApiProductDetailsPage.style";
 import { RedocDisplay } from "./redoc/RedocDisplay";
 import { SwaggerDisplay } from "./swagger/SwaggerDisplay";
@@ -23,7 +23,7 @@ export function ApiSchemaDisplay({
         <Button
           variant="subtle"
           onClick={() => setIsSwagger(!isSwagger)}
-          size="xs"
+          size="sm"
         >
           {isSwagger ? "Redoc" : "Swagger"} View
         </Button>

--- a/projects/ui/src/Components/ApiProductDetails/SchemaTab/redoc/RedocDisplay.style.tsx
+++ b/projects/ui/src/Components/ApiProductDetails/SchemaTab/redoc/RedocDisplay.style.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { borderRadiusConstants } from "../../../../Styles/constants";
-import { makeStyledButtonCSS } from "../../../Common/Button";
+import { makeStyledButtonCSS } from "../ApiSchemaDisplay.style";
 
 /*
 *   EXPLANATION OF TAGS, CLASSNAMES, AND VARIOUS ref HOOKS

--- a/projects/ui/src/Components/ApiProductDetails/SchemaTab/swagger/SwaggerDisplay.style.tsx
+++ b/projects/ui/src/Components/ApiProductDetails/SchemaTab/swagger/SwaggerDisplay.style.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { contentWidth } from "../../../../Styles/ContentWidthHelpers";
 import { borderRadiusConstants } from "../../../../Styles/constants";
-import { makeStyledButtonCSS } from "../../../Common/Button";
+import { makeStyledButtonCSS } from "../ApiSchemaDisplay.style";
 
 /*
 *   EXPLANATION OF div[id^="display-swagger"]

--- a/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiSubscriptionsSection/AppApiSubscriptionsSection.tsx
@@ -1,14 +1,15 @@
-import { Box, Button, Flex } from "@mantine/core";
+import { Box, Flex } from "@mantine/core";
 import { useMemo, useState } from "react";
 import { App, Subscription } from "../../../../Apis/api-types";
 import { Icon } from "../../../../Assets/Icons";
 import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
 import { UtilityStyles } from "../../../../Styles/shared/Utility.style";
+import { Button } from "../../../Common/Button";
 import { EmptyData } from "../../../Common/EmptyData";
 import SubscriptionInfoCard from "../../../Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCard";
 import NewSubscriptionModal from "../Modals/NewSubscriptionModal";
 
-const AddSubscriptionButton = (props: typeof Button.defaultProps) => {
+const AddSubscriptionButton = (props: { onClick: () => void }) => {
   return (
     <Button {...props} variant="subtle">
       <UtilityStyles.ButtonContentsWithIcon>

--- a/projects/ui/src/Components/Apps/Details/EditAppButtonWithModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/EditAppButtonWithModal.tsx
@@ -1,8 +1,9 @@
-import { Button, Tooltip } from "@mantine/core";
+import { Tooltip } from "@mantine/core";
 import { useState } from "react";
 import { App } from "../../../Apis/api-types";
 import { Icon } from "../../../Assets/Icons";
 import { DetailsPageStyles } from "../../../Styles/shared/DetailsPageStyles";
+import { Button } from "../../Common/Button";
 import { EditAppModal } from "./Modals/EditAppModal";
 
 const EditAppButtonWithModal = ({ app }: { app: App }) => {
@@ -11,7 +12,11 @@ const EditAppButtonWithModal = ({ app }: { app: App }) => {
     <>
       <DetailsPageStyles.EditButtonAndTooltipContainer>
         <Tooltip label="Edit App">
-          <Button variant="subtle" onClick={() => setShowEditModal(true)}>
+          <Button
+            isText={false}
+            variant="subtle"
+            onClick={() => setShowEditModal(true)}
+          >
             <Icon.Pencil />
           </Button>
         </Tooltip>

--- a/projects/ui/src/Components/Apps/Details/Modals/DeleteAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/DeleteAppModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CloseButton, Flex, Text } from "@mantine/core";
+import { Box, CloseButton, Flex } from "@mantine/core";
 import { FormEvent } from "react";
 import toast from "react-hot-toast";
 import { di } from "react-magnetic-di";
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { App } from "../../../../Apis/api-types";
 import { useDeleteAppMutation } from "../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Common/Button";
 
 const DeleteAppModal = ({
   app,
@@ -47,11 +48,11 @@ const DeleteAppModal = ({
       <FormModalStyles.HorizLine />
       <Box p="20px 30px 40px 30px">
         <Flex justify={"flex-end"} gap="20px">
-          <Button color="gray.4" onClick={onClose} type="button">
-            <Text color="gray.9">Cancel</Text>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
           </Button>
-          <Button color="red" onClick={onConfirm} type="submit">
-            <Text color="red.0">Delete App</Text>
+          <Button color="danger" onClick={onConfirm} type="submit">
+            Delete App
           </Button>
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Apps/Details/Modals/EditAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/EditAppModal.tsx
@@ -1,10 +1,4 @@
-import {
-  CloseButton,
-  Flex,
-  Input,
-  Button as MantineButton,
-  Text,
-} from "@mantine/core";
+import { CloseButton, Flex, Input } from "@mantine/core";
 import { FormEvent, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { App } from "../../../../Apis/api-types";
@@ -118,18 +112,11 @@ export const EditAppModal = ({
           </div>
 
           <Flex justify={"space-between"}>
-            <MantineButton
-              color="red"
-              size="xs"
-              sx={{ height: "38px", borderRadius: "2px" }}
-              onClick={() => setShowDeleteModal(true)}
-            >
-              <Text color="red.0" weight={500} size="14px">
-                Delete App
-              </Text>
-            </MantineButton>
+            <Button color="danger" onClick={() => setShowDeleteModal(true)}>
+              Delete App
+            </Button>
             <Flex justify={"flex-end"} gap="20px">
-              <Button className="outline" onClick={onClose} type="button">
+              <Button variant="outline" onClick={onClose} type="button">
                 Cancel
               </Button>
               <Button

--- a/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
@@ -82,6 +82,7 @@ const NewSubscriptionModal = ({
         : !formAppId));
   useEffect(() => {
     // The form resets here when `open` or the default fields change.
+    setIsShowingAddAppSubSection(false);
     setFormApiProductId(apiProduct?.id ?? "");
     setFormAppId(app?.id ?? "");
   }, [apiProduct, app, opened]);
@@ -243,7 +244,7 @@ const NewSubscriptionModal = ({
               </FormModalStyles.InputContainer>
             ))}
           <Flex justify={"flex-end"} gap="20px">
-            <Button className="outline" onClick={onClose} type="button">
+            <Button variant="outline" onClick={onClose} type="button">
               Cancel
             </Button>
             <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">

--- a/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
+++ b/projects/ui/src/Components/Apps/Modals/CreateNewAppModal.tsx
@@ -90,7 +90,7 @@ const CreateNewAppModal = ({
             }}
           />
           <Flex justify={"flex-end"} gap="20px">
-            <Button className="outline" onClick={onClose} type="button">
+            <Button variant="outline" onClick={onClose} type="button">
               Cancel
             </Button>
             <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">

--- a/projects/ui/src/Components/Common/Button.tsx
+++ b/projects/ui/src/Components/Common/Button.tsx
@@ -1,161 +1,105 @@
-import { Theme, css } from "@emotion/react";
-import styled from "@emotion/styled";
+import {
+  ButtonProps,
+  DefaultMantineColor,
+  Button as MantineButton,
+  Text,
+  TextProps,
+} from "@mantine/core";
+import { MouseEventHandler } from "react";
+import { borderRadiusConstants } from "../../Styles/constants";
 
-export const makeStyledButtonCSS = (theme: Theme) => css`
-  // A consistent button for general use.
-  //  We've avoided being opionated here about "display"
-  //    type here, but one could certainly follow "inline-..." conventions.
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: currentColor;
-  cursor: pointer;
-
-  border-radius: 2px;
-  height: 40px;
-  min-width: 90px;
-  padding: 0 22px;
-  color: white;
-  font-size: 14px;
-  font-weight: 600;
-  transition: background-color 0.1s linear;
-
-  //
-  // Primary states
-  //
-  border: 1px solid ${theme.januaryGrey};
-  background-color: ${theme.lakeBlue};
-  &:hover {
-    background-color: ${theme.primaryLight10};
-  }
-  &:active {
-    background-color: ${theme.primaryLight20};
-  }
-
-  //
-  // Pale states
-  //
-  &.paleButton {
-    border-color: ${theme.primary};
-    background-color: white;
-    color: ${theme.primary};
-    &:hover {
-      background-color: ${theme.primaryLight10};
-      border-color: ${theme.primaryLight10};
-      color: white;
-    }
-    &:active {
-      background-color: ${theme.primaryLight20};
-      border-color: ${theme.primaryLight20};
-      color: white;
-    }
-  }
-
-  &.smallButton {
-    height: 26px;
-    line-height: 26px;
-  }
-
-  //
-  // Just text states
-  //
-  &.justText {
-    display: inline;
-    height: auto;
-    line-height: inherit;
-    border: none;
-    background-color: transparent;
-    font-size: inherit;
-    padding: 0;
-
-    color: ${theme.primary};
-    font-weight: 500;
-    &:hover {
-      color: ${theme.primaryLight10};
-    }
-    &:active {
-      color: ${theme.primaryLight20};
-    }
-  }
-
-  //
-  // Success states
-  //
-  &.success {
-    background-color: ${theme.midGreen};
-    &:hover {
-      background-color: ${theme.midGreenLight10};
-    }
-    &:active {
-      background-color: ${theme.midGreenLight20};
-    }
-  }
-
-  //
-  // Outline states
-  //
-  &.outline {
-    color: ${theme.lakeBlue};
-    border: 1px solid ${theme.lakeBlue};
-    background-color: white;
-    &:hover {
-      color: white;
-      background-color: ${theme.primaryLight10};
-      border: none;
-    }
-    &:active {
-      color: white;
-      background-color: ${theme.primaryLight20};
-      border: none;
-    }
-  }
-
-  //
-  // Error states
-  //
-  &.error {
-    background-color: ${theme.pumpkinOrange};
-    &:hover {
-      background-color: ${theme.pumpkinOrangeLight10};
-    }
-    &:active {
-      background-color: ${theme.pumpkinOrangeLight20};
-    }
-  }
-
-  //
-  // Disabled states
-  //
-  &.disabled,
-  &.disabled:hover,
-  &.disabled:active {
-    cursor: not-allowed;
-    background-color: ${theme.augustGrey};
-  }
-`;
-
-export const StyledButton = styled.button(({ theme }) =>
-  makeStyledButtonCSS(theme)
-);
+const colorMap: {
+  [key: string]: {
+    button: DefaultMantineColor;
+    lightButton?: DefaultMantineColor;
+    text: DefaultMantineColor;
+  };
+} = {
+  success: {
+    button: "green",
+    text: "green.0",
+  },
+  primary: {
+    button: "blue.6",
+    text: "white",
+  },
+  secondary: {
+    button: "gray.4",
+    text: "gray.9",
+  },
+  warning: {
+    button: "yellow.6",
+    text: "red.6",
+  },
+  danger: {
+    lightButton: "red.4",
+    button: "red.6",
+    text: "red.0",
+  },
+};
 
 export function Button(
-  props: React.DetailedHTMLProps<
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    HTMLButtonElement
-  >
+  props: {
+    color?: "primary" | "success" | "warning" | "danger" | "secondary";
+    variant?: "outline" | "subtle" | "light" | "filled";
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    /**
+     * `isText` defaults to true, and can be set to false to render the contents directly under the button.
+     * This can be used when rendering a single SVG inside the button.
+     */
+    isText?: boolean;
+  } & ButtonProps
 ) {
-  const { disabled, ...rest } = props;
+  // default to a primary, filled button.
+  const color = props.color ?? "primary";
+  const variant = props.variant ?? "filled";
+  const isText = props.isText ?? true;
 
+  const colorInfo = colorMap[color];
+
+  //
+  // Text
+  //
+  let textColor = colorInfo.text;
+  if (variant === "filled") {
+    textColor = colorInfo.text;
+  } else {
+    textColor = colorInfo.button;
+  }
+  const textProps: TextProps = {
+    sx: !props.size ? { fontWeight: 600, fontSize: "14px" } : undefined,
+    size: props.size,
+    color: textColor,
+  };
+
+  //
+  // Button
+  //
+  let buttonColor = colorInfo.button;
+  if (variant === "light") {
+    if (!!colorInfo.lightButton) {
+      buttonColor = colorInfo.lightButton;
+    } else {
+      buttonColor = colorInfo.text;
+    }
+  }
+  const buttonProps: ButtonProps = {
+    sx: { borderRadius: borderRadiusConstants.xs },
+    ...props,
+    variant,
+    color: buttonColor,
+  };
+
+  //
+  // Render
+  //
   return (
-    <StyledButton
-      {...rest}
-      aria-disabled={disabled}
-      tabIndex={disabled ? -1 : 0}
-      className={`styledButton ${rest.className ?? ""} ${
-        disabled ? "disabled" : ""
-      }`}
-    >
-      {rest.children}
-    </StyledButton>
+    <MantineButton {...buttonProps}>
+      {!!isText ? (
+        <Text {...textProps}>{props.children}</Text>
+      ) : (
+        <>{props.children}</>
+      )}
+    </MantineButton>
   );
 }

--- a/projects/ui/src/Components/Common/DataPairPill.tsx
+++ b/projects/ui/src/Components/Common/DataPairPill.tsx
@@ -51,7 +51,6 @@ export function DataPairPill({
       <div>{value}</div>{" "}
       {!!onRemove && (
         <button
-          className="removingX"
           aria-label={`Remove ${pairKey} : ${value} pair`}
           onClick={onRemove}
         >

--- a/projects/ui/src/Components/Common/EmptyData.tsx
+++ b/projects/ui/src/Components/Common/EmptyData.tsx
@@ -1,125 +1,4 @@
-import { css } from "@emotion/react";
-import styled from "@emotion/styled";
-
-const LoadingContainer = styled.div(
-  ({ theme }) => css`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-    padding-bottom: 30px;
-
-    // A pretty spinner while they wait...
-    // .inner and .outer define the two circling balls, and
-    //   their 'color's can be changed here.
-    .loadingSpinner,
-    .emptyCircle {
-      position: relative;
-
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100px;
-      height: 100px;
-
-      .chasePlate {
-        position: absolute;
-        border-radius: 50%;
-        border-style: solid;
-        animation: animateCircles 3s linear infinite;
-
-        &.outer {
-          width: 100%;
-          height: 100%;
-          color: ${theme.primary};
-          border-color: currentColor transparent transparent currentColor;
-          border-width: 0.2em 0.2em 0em 0em;
-          --deg: -45deg;
-          animation-direction: normal;
-        }
-
-        &.inner {
-          width: 65%;
-          height: 65%;
-          color: ${theme.secondary};
-          border-color: currentColor currentColor transparent transparent;
-          border-width: 0.2em 0em 0em 0.2em;
-          --deg: -135deg;
-          animation-direction: reverse;
-        }
-
-        .circle {
-          position: absolute;
-          width: 50%;
-          height: 0.1em;
-          top: 50%;
-          left: 50%;
-          background-color: transparent;
-          transform: rotate(var(--deg));
-          transform-origin: left;
-        }
-
-        .circle::before {
-          position: absolute;
-          content: "";
-          /* width: 1em;
-          height: 1em;
-          top: -0.5em;
-          right: -0.5em; */
-          width: 12px;
-          height: 12px;
-          top: -6px;
-          right: -8px;
-          background-color: currentColor;
-          border-radius: 50%;
-        }
-      }
-    }
-    .emptyCircle {
-      .chasePlate {
-        animation: animateCircles 1.3s linear;
-
-        &.inner,
-        &.outer {
-          border-width: 0.2em;
-          border-color: currentColor;
-        }
-        &.inner {
-          --deg: -90deg;
-        }
-        &.outer {
-          --deg: -90deg;
-        }
-      }
-    }
-
-    .loadingMessage,
-    .emptyMainMessage,
-    .emptyDetailsMessage {
-      padding-top: 20px;
-      text-align: center;
-      font-size: 18px;
-      font-weight: 500;
-
-      color: ${theme.defaultColoredText};
-    }
-    .emptyDetailsMessage {
-      padding-top: 8px;
-      font-size: 16px;
-      line-height: 20px;
-      font-weight: 400;
-    }
-
-    //
-    // Animations
-    //
-    @keyframes animateCircles {
-      to {
-        transform: rotate(1turn);
-      }
-    }
-  `
-);
+import { Flex, Text } from "@mantine/core";
 
 type EmptyDataProps =
   | {
@@ -131,25 +10,19 @@ type EmptyDataProps =
     };
 export function EmptyData(props: EmptyDataProps) {
   return (
-    <LoadingContainer aria-hidden="true">
-      <div className="emptyCircle">
-        <div className="chasePlate outer">
-          <div className="circle"></div>
-        </div>
-        <div className="chasePlate inner">
-          <div className="circle"></div>
-        </div>
-      </div>
-      {"topicMessageOverride" in props ? (
-        <div className="emptyMainMessage">{props.topicMessageOverride}</div>
-      ) : (
-        <div className="emptyMainMessage">
-          No {props.topic} results were found
-        </div>
-      )}
+    <Flex justify={"center"}>
+      <Text color="gray.6" italic>
+        {"topicMessageOverride" in props ? (
+          <>{props.topicMessageOverride}</>
+        ) : (
+          <>No {props.topic} results were found</>
+        )}
+      </Text>
       {"message" in props && !!props.message && (
-        <div className="emptyDetailsMessage">{props.message}</div>
+        <Text color="gray.6" italic>
+          {props.message}
+        </Text>
       )}
-    </LoadingContainer>
+    </Flex>
   );
 }

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/Modals/ApproveSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/Modals/ApproveSubscriptionModal.tsx
@@ -1,10 +1,11 @@
-import { Box, Button, CloseButton, Flex, Text } from "@mantine/core";
+import { Box, CloseButton, Flex } from "@mantine/core";
 import { FormEvent } from "react";
 import toast from "react-hot-toast";
 import { di } from "react-magnetic-di";
 import { Subscription } from "../../../../../Apis/api-types";
 import { useAdminApproveSubscriptionMutation } from "../../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Button";
 
 const ApproveSubscriptionModal = ({
   subscription,
@@ -44,11 +45,11 @@ const ApproveSubscriptionModal = ({
       <FormModalStyles.HorizLine />
       <Box p="20px 30px 40px 30px">
         <Flex justify={"flex-end"} gap="20px">
-          <Button color="gray.4" onClick={onClose} type="button">
-            <Text color="gray.9">Cancel</Text>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
           </Button>
-          <Button color="green" onClick={onConfirm} type="submit">
-            <Text color="green.0">Approve Subscription</Text>
+          <Button color="success" onClick={onConfirm} type="submit">
+            Approve Subscription
           </Button>
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/Modals/DeleteSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/Modals/DeleteSubscriptionModal.tsx
@@ -1,10 +1,11 @@
-import { Box, Button, CloseButton, Flex, Text } from "@mantine/core";
+import { Box, CloseButton, Flex } from "@mantine/core";
 import { FormEvent } from "react";
 import toast from "react-hot-toast";
 import { di } from "react-magnetic-di";
 import { Subscription } from "../../../../../Apis/api-types";
 import { useDeleteSubscriptionMutation } from "../../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Button";
 
 const DeleteSubscriptionModal = ({
   subscription,
@@ -44,11 +45,11 @@ const DeleteSubscriptionModal = ({
       <FormModalStyles.HorizLine />
       <Box p="20px 30px 40px 30px">
         <Flex justify={"flex-end"} gap="20px">
-          <Button color="gray.4" onClick={onClose} type="button">
-            <Text color="gray.9">Cancel</Text>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
           </Button>
-          <Button color="red" onClick={onConfirm} type="submit">
-            <Text color="red.0">Delete Subscription</Text>
+          <Button color="danger" onClick={onConfirm} type="submit">
+            Delete Subscription
           </Button>
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/Modals/RejectSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/Modals/RejectSubscriptionModal.tsx
@@ -1,10 +1,11 @@
-import { Box, Button, CloseButton, Flex, Text } from "@mantine/core";
+import { Box, CloseButton, Flex } from "@mantine/core";
 import { FormEvent } from "react";
 import toast from "react-hot-toast";
 import { di } from "react-magnetic-di";
 import { Subscription } from "../../../../../Apis/api-types";
 import { useAdminRejectSubscriptionMutation } from "../../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Button";
 
 const RejectSubscriptionModal = ({
   subscription,
@@ -44,11 +45,11 @@ const RejectSubscriptionModal = ({
       <FormModalStyles.HorizLine />
       <Box p="20px 30px 40px 30px">
         <Flex justify={"flex-end"} gap="20px">
-          <Button color="gray.4" onClick={onClose} type="button">
-            <Text color="gray.9">Cancel</Text>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
           </Button>
-          <Button color="yellow" onClick={onConfirm} type="submit">
-            <Text color="red.9">Reject Subscription</Text>
+          <Button color="warning" onClick={onConfirm} type="submit">
+            Reject Subscription
           </Button>
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardAdminFooter.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardAdminFooter.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, Flex, Text } from "@mantine/core";
+import { Box, Flex } from "@mantine/core";
 import { useState } from "react";
 import { Subscription } from "../../../../Apis/api-types";
+import { Button } from "../../Button";
 import { SubscriptionState } from "../SubscriptionsUtility";
 import ApproveSubscriptionModal from "./Modals/ApproveSubscriptionModal";
 import DeleteSubscriptionModal from "./Modals/DeleteSubscriptionModal";
@@ -31,36 +32,30 @@ const SubscriptionInfoCardAdminFooter = ({
         <Box py="5px">
           <Flex gap="15px" wrap={"wrap"}>
             <Button
-              color="green"
+              color="success"
               size="xs"
               disabled={!canApproveRejectSubscription}
               onClick={() => setShowApproveSubModal(true)}
             >
-              <Text color="green.0" weight={500}>
-                Approve
-              </Text>
+              Approve
             </Button>
 
             <Button
-              color="yellow"
+              color="warning"
               size="xs"
               disabled={!canApproveRejectSubscription}
               onClick={() => setShowRejectSubModal(true)}
             >
-              <Text color="red.6" weight={500}>
-                Reject
-              </Text>
+              Reject
             </Button>
 
             <Button
-              color="red"
+              color="danger"
               size="xs"
               disabled={!canDeleteSubscription}
               onClick={() => setShowDeleteSubModal(true)}
             >
-              <Text color="red.0" weight={500}>
-                Delete
-              </Text>
+              Delete
             </Button>
           </Flex>
         </Box>

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardFooter.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardFooter.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Text } from "@mantine/core";
+import { Box, Flex } from "@mantine/core";
 import { useState } from "react";
 import { NavLink } from "react-router-dom";
 import { Subscription } from "../../../../Apis/api-types";
@@ -7,6 +7,7 @@ import {
   getApiProductDetailsDocsTabLink,
   getApiProductDetailsSpecTabLink,
 } from "../../../../Utility/link-builders";
+import { Button } from "../../Button";
 import { SubscriptionState } from "../SubscriptionsUtility";
 import DeleteSubscriptionModal from "./Modals/DeleteSubscriptionModal";
 import { SubscriptionInfoCardStyles } from "./SubscriptionInfoCard.style";
@@ -50,14 +51,12 @@ const SubscriptionInfoCardFooter = ({
             </UtilityStyles.NavLinkContainer>
           </Flex>
           <Button
-            color="red"
+            color="danger"
             size="xs"
             disabled={!canDeleteSubscription}
             onClick={() => setShowDeleteSubModal(true)}
           >
-            <Text color="red.0" weight={500}>
-              Delete
-            </Text>
+            Delete
           </Button>
         </Flex>
       </SubscriptionInfoCardStyles.Footer>

--- a/projects/ui/src/Components/Common/ToggleAddButton.tsx
+++ b/projects/ui/src/Components/Common/ToggleAddButton.tsx
@@ -1,6 +1,6 @@
-import { Button } from "@mantine/core";
 import { Icon } from "../../Assets/Icons";
 import { UtilityStyles } from "../../Styles/shared/Utility.style";
+import { Button } from "./Button";
 
 /**
  * Shared between details pages.

--- a/projects/ui/src/Components/Teams/Details/AppsSection/AddTeamAppSubSection.tsx
+++ b/projects/ui/src/Components/Teams/Details/AppsSection/AddTeamAppSubSection.tsx
@@ -84,11 +84,7 @@ const AddTeamAppSubSection = ({
             value={formAppDescription}
             onChange={(e) => setFormAppDescription(e.target.value)}
           />
-          <Button
-            className={`small ${isFormDisabled ? "disabled" : ""}`}
-            disabled={isFormDisabled}
-            type={"submit"}
-          >
+          <Button disabled={isFormDisabled} type={"submit"}>
             ADD APP
           </Button>
         </DetailsPageStyles.AddItemForm>

--- a/projects/ui/src/Components/Teams/Details/EditTeamButtonWithModal.tsx
+++ b/projects/ui/src/Components/Teams/Details/EditTeamButtonWithModal.tsx
@@ -1,8 +1,9 @@
-import { Button, Tooltip } from "@mantine/core";
+import { Tooltip } from "@mantine/core";
 import { useState } from "react";
 import { Team } from "../../../Apis/api-types";
 import { Icon } from "../../../Assets/Icons";
 import { DetailsPageStyles } from "../../../Styles/shared/DetailsPageStyles";
+import { Button } from "../../Common/Button";
 import { EditTeamModal } from "./Modals/EditTeamModal";
 
 const EditTeamButtonWithModal = ({ team }: { team: Team }) => {
@@ -11,7 +12,11 @@ const EditTeamButtonWithModal = ({ team }: { team: Team }) => {
     <>
       <DetailsPageStyles.EditButtonAndTooltipContainer>
         <Tooltip label="Edit Team">
-          <Button variant="subtle" onClick={() => setShowEditModal(true)}>
+          <Button
+            isText={false}
+            variant="subtle"
+            onClick={() => setShowEditModal(true)}
+          >
             <Icon.Pencil />
           </Button>
         </Tooltip>

--- a/projects/ui/src/Components/Teams/Details/Modals/ConfirmRemoveTeamMemberModal.tsx
+++ b/projects/ui/src/Components/Teams/Details/Modals/ConfirmRemoveTeamMemberModal.tsx
@@ -1,9 +1,10 @@
-import { Box, Button, CloseButton, Flex, Text } from "@mantine/core";
+import { Box, CloseButton, Flex } from "@mantine/core";
 import { FormEvent } from "react";
 import toast from "react-hot-toast";
 import { di } from "react-magnetic-di";
 import { useRemoveTeamMemberMutation } from "../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Common/Button";
 
 const ConfirmRemoveTeamMemberModal = ({
   userId,
@@ -45,11 +46,11 @@ const ConfirmRemoveTeamMemberModal = ({
       <FormModalStyles.HorizLine />
       <Box p="20px 30px 40px 30px">
         <Flex justify={"flex-end"} gap="20px">
-          <Button color="gray.4" onClick={onClose} type="button">
-            <Text color="gray.9">Cancel</Text>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
           </Button>
-          <Button color="red" onClick={onConfirm} type="submit">
-            <Text color="red.0">Remove User</Text>
+          <Button color="danger" onClick={onConfirm} type="submit">
+            Remove User
           </Button>
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Teams/Details/Modals/DeleteTeamModal.tsx
+++ b/projects/ui/src/Components/Teams/Details/Modals/DeleteTeamModal.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CloseButton, Flex, Text } from "@mantine/core";
+import { Box, CloseButton, Flex } from "@mantine/core";
 import { FormEvent } from "react";
 import toast from "react-hot-toast";
 import { di } from "react-magnetic-di";
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { Team } from "../../../../Apis/api-types";
 import { useDeleteTeamMutation } from "../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
+import { Button } from "../../../Common/Button";
 
 const DeleteTeamModal = ({
   team,
@@ -47,11 +48,11 @@ const DeleteTeamModal = ({
       <FormModalStyles.HorizLine />
       <Box p="20px 30px 40px 30px">
         <Flex justify={"flex-end"} gap="20px">
-          <Button color="gray.4" onClick={onClose} type="button">
-            <Text color="gray.9">Cancel</Text>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
           </Button>
-          <Button color="red" onClick={onConfirm} type="submit">
-            <Text color="red.0">Delete Team</Text>
+          <Button color="danger" onClick={onConfirm} type="submit">
+            Delete Team
           </Button>
         </Flex>
       </Box>

--- a/projects/ui/src/Components/Teams/Details/Modals/EditTeamModal.tsx
+++ b/projects/ui/src/Components/Teams/Details/Modals/EditTeamModal.tsx
@@ -1,10 +1,4 @@
-import {
-  CloseButton,
-  Flex,
-  Input,
-  Button as MantineButton,
-  Text,
-} from "@mantine/core";
+import { CloseButton, Flex, Input } from "@mantine/core";
 import { FormEvent, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Team } from "../../../../Apis/api-types";
@@ -117,18 +111,11 @@ export const EditTeamModal = ({
           </div>
 
           <Flex justify={"space-between"}>
-            <MantineButton
-              color="red"
-              size="xs"
-              sx={{ height: "38px", borderRadius: "2px" }}
-              onClick={() => setShowDeleteModal(true)}
-            >
-              <Text color="red.0" weight={500} size="14px">
-                Delete Team
-              </Text>
-            </MantineButton>
+            <Button color="danger" onClick={() => setShowDeleteModal(true)}>
+              Delete Team
+            </Button>
             <Flex justify={"flex-end"} gap="20px">
-              <Button className="outline" onClick={onClose} type="button">
+              <Button variant="outline" onClick={onClose} type="button">
                 Cancel
               </Button>
               <Button

--- a/projects/ui/src/Components/Teams/Details/UsersSection/TeamUsersSection.tsx
+++ b/projects/ui/src/Components/Teams/Details/UsersSection/TeamUsersSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Button as MantineButton, Text } from "@mantine/core";
+import { Box, Flex } from "@mantine/core";
 import { useMemo, useState } from "react";
 import { di } from "react-magnetic-di";
 import { Member, Team } from "../../../../Apis/api-types";
@@ -11,6 +11,7 @@ import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { UtilityStyles } from "../../../../Styles/shared/Utility.style";
 import { formatDateToMMDDYYYY } from "../../../../Utility/utility";
+import { Button } from "../../../Common/Button";
 import { EmptyData } from "../../../Common/EmptyData";
 import { Loading } from "../../../Common/Loading";
 import Pagination, { usePagination } from "../../../Common/Pagination";
@@ -58,16 +59,15 @@ const TeamUsersSection = ({ team }: { team: Team }) => {
             </td>
             <td>
               <UtilityStyles.CenteredCellContent>
-                <MantineButton
+                <Button
                   size="xs"
-                  color="red.0"
+                  variant="light"
+                  color="danger"
                   disabled={!!member.deletedAt || user?.email === member.email}
                   onClick={() => setConfirmRemoveTeamMember(member)}
                 >
-                  <Text color="red.6" size="xs">
-                    REMOVE
-                  </Text>
-                </MantineButton>
+                  REMOVE
+                </Button>
               </UtilityStyles.CenteredCellContent>
             </td>
           </tr>

--- a/projects/ui/src/Components/Teams/Modals/CreateNewTeamModal.tsx
+++ b/projects/ui/src/Components/Teams/Modals/CreateNewTeamModal.tsx
@@ -94,7 +94,7 @@ const CreateNewTeamModal = ({
           />
         </FormModalStyles.InputContainer>
         <Flex justify={"flex-end"} gap="20px">
-          <Button className="outline" onClick={onClose} type="button">
+          <Button variant="outline" onClick={onClose} type="button">
             Cancel
           </Button>
           <Button disabled={isFormDisabled} onClick={onSubmit} type="submit">

--- a/projects/ui/src/Styles/colors.ts
+++ b/projects/ui/src/Styles/colors.ts
@@ -1,73 +1,33 @@
 import Color from "color";
 
-// We can lighten and darken colors using the color package.
-// https://www.npmjs.com/package/color
-
-const colorMap = {
-  /**
-   * SIZING
-   **/
-  // normalContentWidth: "1385px",
-  // largeContentWidth: "1920px",
-
-  // standardBorderRadius: "15px",
-  // smallBorderRadius: "4px",
-
-  /**
-   * COLORS
-   **/
+const baseColors = {
   januaryGrey: "#f0f5f7",
   marchGrey: "#e9eef3",
-  marchGreyDark3: "#dfe6ee",
-  marchGreyDark5: "#d9e1ea",
-  marchGreyDark10: "#c8d5e1",
-  marchGreyLight5: "#fafbfc",
   aprilGrey: "#d4d8de",
-  aprilGreyDark10: Color("#d4d8de").darken(0.1).hex(),
   augustGrey: "#8693a5",
   septemberGrey: "#6e7477",
   novemberGrey: "#35393b",
 
   lightGreyTransparent: "#ccd4db21",
-  lightGreyTransparentDark10: "rgba(174, 187, 198, 0.1294117647)",
-  lightGreyTransparentDark25: "rgba(129, 149, 166, 0.1294117647)",
-  midGreyTransparent: "#253e580b",
   darkGreyTransparent: "#253e5812",
-  blackTransparent: "#00000026",
-
-  greyOpaque: "#8693a5a2",
-  greyBlueOpaque: "#253e58cc",
 
   dropBlue: "#f8fafb",
   splashBlue: "#dbe4ec",
-  splashBlueLight5: "#ecf1f5",
-  splashBlueLight7: "#f2f6f8",
-  splashBlueLight10: "#fcfdfe",
-  splashBlueDark10: "#bacbda",
   pondBlue: "#55b8e3",
   lakeBlue: "#158bc2",
-  lakeBlueDark10: "#1274a2",
-  lakeBlueLight10: "#23a9e7",
-  lakeBlueLight20: "#51bbec",
   seaBlue: "#45698a",
   oceanBlue: "#325476",
   neptuneBlue: "#253e58",
 
   lightGreen: "#ebfff9",
   midGreen: "#0dce93",
-  midGreenLight10: "#1df1b0",
-  midGreenLight20: "#4df4c1",
   darkGreen: "#0fac7c",
-  darkGreenDark20: Color("#0fac7c").darken(0.2).hex(),
 
   royalPurple: "#7e4bc6",
 
   lightRed: "#fff7f7",
-  lightRedDark10: Color("#fff7f7").darken(0.1).desaturate(0.25).hex(),
-  lightMidRed: Color("#bf0a17").lighten(1.2).desaturate(0.2).hex(),
   midRed: "#bf0a17",
   darkRed: "#a23f3a",
-  darkRedDark20: Color("#a23f3a").darken(0.2).hex(),
 
   pumpkinOrange: "#d75b1d",
   pumpkinOrangeLight10: "#e57842",
@@ -75,16 +35,47 @@ const colorMap = {
 
   lightYellow: "#fff6e5",
   midYellow: "#ffb831",
-  midYellowDark20: Color("#ffb831").darken(0.2).hex(),
   darkYellow: "#c98709",
-  darkYellowDark20: Color("#c98709").darken(0.2).hex(),
+} as const;
 
-  // SEMANTIC COLORS
-} as const; // "as const" forces all the color values to be an `as const` value instead of `string`
+// We can modify the base colors using the color package.
+// https://www.npmjs.com/package/color
+const colorMap = {
+  ...baseColors,
 
-// Site wide
+  marchGreyDark3: Color(baseColors.marchGrey).darken(0.03).hex(),
+  marchGreyDark5: Color(baseColors.marchGrey).darken(0.05).hex(),
+  marchGreyDark10: Color(baseColors.marchGrey).darken(0.1).hex(),
+  marchGreyLight5: Color(baseColors.marchGrey).lighten(0.05).hex(),
+
+  aprilGreyDark10: Color(baseColors.aprilGrey).darken(0.1).hex(),
+
+  splashBlueLight5: Color(baseColors.splashBlue).lighten(0.05).hex(),
+  splashBlueLight7: Color(baseColors.splashBlue).lighten(0.07).hex(),
+  splashBlueLight10: Color(baseColors.splashBlue).lighten(0.1).hex(),
+  splashBlueDark10: Color(baseColors.splashBlue).darken(0.1).hex(),
+
+  lakeBlueDark10: Color(baseColors.lakeBlue).darken(0.1).hex(),
+  lakeBlueLight10: Color(baseColors.lakeBlue).lighten(0.1).hex(),
+  lakeBlueLight20: Color(baseColors.lakeBlue).lighten(0.2).hex(),
+
+  midGreenLight10: Color(baseColors.midGreen).lighten(0.1).hex(),
+  midGreenLight20: Color(baseColors.midGreen).lighten(0.2).hex(),
+
+  darkGreenDark20: Color(baseColors.darkGreen).darken(0.2).hex(),
+
+  lightRedDark10: Color(baseColors.lightRed).darken(0.1).desaturate(0.25).hex(),
+  lightMidRed: Color(baseColors.midRed).lighten(1.2).desaturate(0.2).hex(),
+  darkRedDark20: Color(baseColors.darkRed).darken(0.2).hex(),
+
+  pumpkinOrangeLight10: Color(baseColors.pumpkinOrange).lighten(0.1).hex(),
+  pumpkinOrangeLight20: Color(baseColors.pumpkinOrange).lighten(0.2).hex(),
+
+  midYellowDark20: Color(baseColors.midYellow).darken(0.2).hex(),
+} as const;
+
 const semanticColorMap = {
-  modalBack: colorMap.greyBlueOpaque,
+  // Site wide
   primary: colorMap.lakeBlue,
   primaryLight10: colorMap.lakeBlueLight10,
   primaryLight20: colorMap.lakeBlueLight20,
@@ -92,7 +83,6 @@ const semanticColorMap = {
   background: colorMap.dropBlue,
   defaultText: colorMap.novemberGrey,
   defaultColoredText: colorMap.neptuneBlue,
-  iconsColor: colorMap.lakeBlue,
   internalLinkColor: colorMap.lakeBlue,
   internalLinkColorDark10: colorMap.lakeBlueDark10,
   externalLinkColor: colorMap.neptuneBlue,
@@ -107,4 +97,5 @@ const semanticColorMap = {
   apiDocumentationText: colorMap.neptuneBlue,
 } as const;
 
+// Exporting "as const" forces all the color values to be an `as const` value instead of `string`.
 export const colors = { ...colorMap, ...semanticColorMap } as const;

--- a/projects/ui/src/Styles/constants.ts
+++ b/projects/ui/src/Styles/constants.ts
@@ -1,4 +1,5 @@
 export const borderRadiusConstants = {
   standard: "15px",
   small: "4px",
+  xs: "2px",
 } as const;

--- a/projects/ui/src/Styles/global-styles/mantine-theme.ts
+++ b/projects/ui/src/Styles/global-styles/mantine-theme.ts
@@ -57,5 +57,17 @@ export const mantineThemeOverride: MantineThemeOverride = {
       colors.darkGreenDark20,
       colors.darkGreenDark20,
     ],
+    blue: [
+      colors.splashBlue, // button text, subtle-button hover
+      colors.lakeBlue,
+      colors.lakeBlue,
+      colors.lakeBlue,
+      colors.lakeBlue,
+      colors.lakeBlue,
+      colors.lakeBlue, // button standard color
+      colors.lakeBlueDark10, // button hover + active color
+      colors.lakeBlueDark10,
+      colors.neptuneBlue,
+    ],
   },
 };

--- a/projects/ui/src/Styles/shared/DetailsPageStyles.tsx
+++ b/projects/ui/src/Styles/shared/DetailsPageStyles.tsx
@@ -62,7 +62,6 @@ export namespace DetailsPageStyles {
         min-width: unset;
       }
       svg {
-        /* width: 20px; */
         height: 100%;
       }
       ${svgColorReplace(theme.augustGrey)}


### PR DESCRIPTION
This PR:
- Updates the colors file to use the colors NPM package more consistently and use variables for base colors.
- Adds the filter by rejected option to the admin subscriptions page.
- Removes the no results animation so that it's just text based on feedback that the animation may indicate something is loading.
- Updates the `Common/Button` component to use a themed Mantine button.

<img width="1322" alt="Screenshot 2024-04-09 at 2 05 29 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/4e284c34-9e11-461c-8f1c-a91c812bb832">

