### PR TITLE
Charlesthebird/errors refactor

### DIFF
--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -96,9 +96,13 @@ export type Subscription = {
   updatedAt: string;
 };
 
+/**
+ * This is an error message that is returned by the useMultiSwrWithAuth function.
+ * Since it includes multiple requests, it wouldn't be a good UX to throw an error if one fails.
+ * Instead we can filter on isError and show the results that succeeded.
+ */
 export type ErrorMessageResponse = {
-  // TODO: This isn't used but could be useful in a refactor.
-  // isError: true;
+  isError: true;
   message: string;
 };
 

--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -106,6 +106,21 @@ export type ErrorMessageResponse = {
   message: string;
 };
 
+export const isErrorMessageResponse = <T>(value: T | ErrorMessageResponse) =>
+  value !== null &&
+  typeof value === "object" &&
+  "isError" in value &&
+  !!value.isError;
+
+/**
+ * This may be returned from the subscriptions list endpoint, and if so is an error.
+ */
+export type SubscriptionsListError = { message: string };
+
+export const isSubscriptionsListError = (
+  s: SubscriptionsListError | Subscription[] | undefined
+) => !!s && typeof s === "object" && "message" in s;
+
 type SchemaPropertyType = "string" | "integer" | "array" | "object";
 export type ApiVersionSchema = {
   components?: {

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -8,7 +8,6 @@ import {
   ApiProductSummary,
   ApiVersion,
   App,
-  ErrorMessageResponse,
   Member,
   Subscription,
   SubscriptionStatus,
@@ -38,7 +37,7 @@ export function useListAppsForTeams(teams: Team[]) {
     skipFetching ? null : TEAM_APPS_SWR_KEY
   );
 }
-export function useListFlatAppsForTeams(teams: Team[]) {
+export function useListFlatAppsForTeamsOmitErrors(teams: Team[]) {
   // This flattens the apps for teams result, in cases where we don't
   // need the mapped team data.
   const swrRes = useListAppsForTeams(teams);
@@ -81,7 +80,7 @@ export function useGetApiProductVersions(id?: string) {
 // Subscriptions
 // this is an admin endpoint
 export function useListSubscriptionsForStatus(status: SubscriptionStatus) {
-  const swrResponse = useSwrWithAuth<Subscription[] | ErrorMessageResponse>(
+  const swrResponse = useSwrWithAuth<Subscription[]>(
     `/subscriptions?status=${status}`
   );
   useEffect(() => {

--- a/projects/ui/src/Apis/utility.ts
+++ b/projects/ui/src/Apis/utility.ts
@@ -23,12 +23,6 @@ async function doFetch(...args: Parameters<typeof fetch>) {
       ...args[1],
       headers: {
         ...args[1]?.headers,
-        // TODO: Could remove this once auth is working.
-        ...(import.meta.env.VITE_AUTH_HEADER
-          ? {
-              Authorization: import.meta.env.VITE_AUTH_HEADER,
-            }
-          : {}),
         "Content-Type": "application/json",
       },
     },
@@ -100,16 +94,6 @@ export const useSwrWithAuth = <T>(
   );
 };
 
-// /**
-//  * TODO: This isn't used but could be useful in a refactor.
-//  */
-// export const useSwrWithAuthOmitError = <T>(
-//   ...args: Parameters<typeof useSwrWithAuth<T>>
-// ) => {
-//   const swrRes = useSwrWithAuth<T>(...args);
-//   return { ...swrRes, data: omitErrorMessageResponse(swrRes.data) };
-// };
-
 /**
  *  This is the same as useSwrWithAuth, but works for an array of paths.
  * e.g.`["/teams/team-id-1/apps", "/teams/team-id-2/apps", ...]` will return:
@@ -143,8 +127,7 @@ export const useMultiSwrWithAuth = <T>(
             });
           } catch (message) {
             const errMsgRes: ErrorMessageResponse = {
-              // TODO: This isn't used but could be useful in a refactor.
-              // isError: true,
+              isError: true,
               message: JSON.stringify(message),
             };
             return errMsgRes;

--- a/projects/ui/src/Components/AdminSubscriptions/AdminSubscriptionsPage.tsx
+++ b/projects/ui/src/Components/AdminSubscriptions/AdminSubscriptionsPage.tsx
@@ -2,7 +2,7 @@ import { Box } from "@mantine/core";
 import { useMemo, useState } from "react";
 import { Subscription } from "../../Apis/api-types";
 import {
-  useListFlatAppsForTeams,
+  useListFlatAppsForTeamsOmitErrors,
   useListSubscriptionsForApps,
   useListTeams,
 } from "../../Apis/hooks";
@@ -26,7 +26,7 @@ const AdminSubscriptionsPage = () => {
 
   // Then the apps for those teams (these are the apps we can access)...
   const { isLoading: isLoadingApps, data: flatAppsForTeams } =
-    useListFlatAppsForTeams(teams ?? []);
+    useListFlatAppsForTeamsOmitErrors(teams ?? []);
 
   // Then the subscriptions for the apps...
   const { isLoading: isLoadingSubscriptions, data: subscriptionsForApps } =

--- a/projects/ui/src/Components/Apis/ApisPage.tsx
+++ b/projects/ui/src/Components/Apis/ApisPage.tsx
@@ -2,7 +2,10 @@ import { Box, Flex, Loader, Tabs } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { di } from "react-magnetic-di";
 import { useLocation, useNavigate } from "react-router-dom";
-import { SubscriptionStatus } from "../../Apis/api-types";
+import {
+  SubscriptionStatus,
+  isSubscriptionsListError,
+} from "../../Apis/api-types";
 import {
   useListApiProducts,
   useListSubscriptionsForStatus,
@@ -33,7 +36,9 @@ export function ApisPage() {
     error: subscriptionsErr,
   } = useListSubscriptionsForStatus(SubscriptionStatus.PENDING);
   const subscriptionsError =
-    !!subscriptionsErr || (subscriptions && "message" in subscriptions);
+    !!subscriptionsErr ||
+    isSubscriptionsListError(subscriptions) ||
+    !Array.isArray(subscriptions);
   const isLoading = isLoadingApiProducts || isLoadingSubscriptions;
 
   //

--- a/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
+++ b/projects/ui/src/Components/Apps/Details/Modals/NewSubscriptionModal.tsx
@@ -13,7 +13,7 @@ import {
   useCreateSubscriptionMutation,
   useListApiProducts,
   useListAppsForTeams,
-  useListFlatAppsForTeams,
+  useListFlatAppsForTeamsOmitErrors,
   useListTeams,
 } from "../../../../Apis/hooks";
 import { FormModalStyles } from "../../../../Styles/shared/FormModalStyles";
@@ -51,9 +51,8 @@ const NewSubscriptionModal = ({
   const { isLoading: isLoadingApiProducts, data: apiProducts } =
     useListApiProducts();
   const { isLoading: isLoadingTeams, data: teams } = useListTeams();
-  const { isLoading: isLoadingApps, data: apps } = useListFlatAppsForTeams(
-    teams ?? []
-  );
+  const { isLoading: isLoadingApps, data: apps } =
+    useListFlatAppsForTeamsOmitErrors(teams ?? []);
 
   //
   // Form Fields

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCard.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCard.tsx
@@ -60,7 +60,7 @@ const SubscriptionInfoCard = ({
       apps?.find(
         (app) =>
           omitErrorMessageResponse(app)?.id === subscription.applicationId
-      )
+      ) ?? null
     );
   }, [apps, subscription]);
 

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionsList.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionsList.tsx
@@ -1,5 +1,9 @@
 import { Box, Flex, Loader } from "@mantine/core";
-import { Subscription } from "../../../Apis/api-types";
+import {
+  Subscription,
+  SubscriptionsListError,
+  isSubscriptionsListError,
+} from "../../../Apis/api-types";
 import { colors } from "../../../Styles";
 import { EmptyData } from "../../Common/EmptyData";
 import { FiltrationProp } from "../Filters/AppliedFiltersSection";
@@ -11,11 +15,11 @@ const SubscriptionsList = ({
   filters,
 }: {
   isLoadingSubscriptions: boolean;
-  subscriptions: Subscription[] | { message: string } | undefined;
+  subscriptions: Subscription[] | SubscriptionsListError | undefined;
   filters?: FiltrationProp;
 }) => {
-  // If the subscriptions list has a message, it is an error and shouldn't be displayed.
-  const subscriptionsError = subscriptions && "message" in subscriptions;
+  const subscriptionsError =
+    !Array.isArray(subscriptions) || isSubscriptionsListError(subscriptions);
 
   //
   // Render

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionsList.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionsList.tsx
@@ -14,6 +14,7 @@ const SubscriptionsList = ({
   subscriptions: Subscription[] | { message: string } | undefined;
   filters?: FiltrationProp;
 }) => {
+  // If the subscriptions list has a message, it is an error and shouldn't be displayed.
   const subscriptionsError = subscriptions && "message" in subscriptions;
 
   //

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionsList.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionsList.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Loader } from "@mantine/core";
-import { ErrorMessageResponse, Subscription } from "../../../Apis/api-types";
+import { Subscription } from "../../../Apis/api-types";
 import { colors } from "../../../Styles";
 import { EmptyData } from "../../Common/EmptyData";
 import { FiltrationProp } from "../Filters/AppliedFiltersSection";
@@ -11,7 +11,7 @@ const SubscriptionsList = ({
   filters,
 }: {
   isLoadingSubscriptions: boolean;
-  subscriptions: Subscription[] | ErrorMessageResponse | undefined;
+  subscriptions: Subscription[] | { message: string } | undefined;
   filters?: FiltrationProp;
 }) => {
   const subscriptionsError = subscriptions && "message" in subscriptions;

--- a/projects/ui/src/Components/Structure/HeaderSectionLoggedIn.tsx
+++ b/projects/ui/src/Components/Structure/HeaderSectionLoggedIn.tsx
@@ -29,7 +29,7 @@ export const StyledUserDropdown = styled(Popover.Dropdown)(
       border-bottom: 0px solid transparent !important;
       color: ${theme.defaultColoredText};
 
-      &:first-child {
+      &:first-of-type {
         border-top-left-radius: 2px;
         border-top-right-radius: 2px;
       }

--- a/projects/ui/src/Utility/utility.ts
+++ b/projects/ui/src/Utility/utility.ts
@@ -102,27 +102,17 @@ export function capitalize(input: string) {
   return input[0].toUpperCase() + input.substring(1);
 }
 
-// /**
-//  * TODO: This isn't used but could be useful in a refactor
-//  */
-// export function isErrorMessageResponse<T>(value: T | ErrorMessageResponse) {
-//   return (
-//     value !== null &&
-//     typeof value === "object" &&
-//     "isError" in value &&
-//     !!value.isError
-//   );
-// }
+export function isErrorMessageResponse<T>(value: T | ErrorMessageResponse) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "isError" in value &&
+    !!value.isError
+  );
+}
 
 export function omitErrorMessageResponse<T>(value: T | ErrorMessageResponse) {
-  // TODO: This isn't used but could be useful in a refactor
-  // if (value === null || isErrorMessageResponse(value)) {
-  //   return null;
-  // }
-  if (value === null) {
-    return null;
-  }
-  if (typeof value === "object" && "message" in value) {
+  if (value === null || isErrorMessageResponse(value)) {
     return null;
   }
   return value as T;

--- a/projects/ui/src/Utility/utility.ts
+++ b/projects/ui/src/Utility/utility.ts
@@ -2,7 +2,10 @@
 // From https://stackoverflow.com/a/65996386
 // navigator.clipboard.writeText doesn't always work.
 
-import { ErrorMessageResponse } from "../Apis/api-types";
+import {
+  ErrorMessageResponse,
+  isErrorMessageResponse,
+} from "../Apis/api-types";
 
 //
 export async function copyToClipboard(textToCopy: string) {
@@ -100,15 +103,6 @@ export function getEnumValues<Enum>(pEnum: StandardEnum<Enum>): Enum[] {
  */
 export function capitalize(input: string) {
   return input[0].toUpperCase() + input.substring(1);
-}
-
-export function isErrorMessageResponse<T>(value: T | ErrorMessageResponse) {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "isError" in value &&
-    !!value.isError
-  );
 }
 
 export function omitErrorMessageResponse<T>(value: T | ErrorMessageResponse) {


### PR DESCRIPTION
This PR 
- Addresses the leftover TODO's related to the error message types. In particular, it adds the `isError` property to the `ErrorMessageResponse`, to distinguish the successful and failed results.
- Changes a `:first-child` to `:first-of-type` to prevent a browser warning - I checked that this did not alter the styling.

Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/16177