### PR TITLE
updates for gloo gateway

### DIFF
--- a/projects/ui/index.html
+++ b/projects/ui/index.html
@@ -10,5 +10,10 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if (global === undefined) {
+        var global = window;
+      }
+    </script>
   </body>
 </html>

--- a/projects/ui/src/Apis/hooks.ts
+++ b/projects/ui/src/Apis/hooks.ts
@@ -70,13 +70,13 @@ export function useGetTeamDetails(id?: string) {
 
 // Api Products
 export function useListApiProducts() {
-  return useSwrWithAuth<ApiProductSummary[]>("/api-products");
+  return useSwrWithAuth<ApiProductSummary[]>("/apis");
 }
 export function useGetApiProductDetails(id?: string) {
-  return useSwrWithAuth<ApiProductDetails>(`/api-products/${id}`);
+  return useSwrWithAuth<ApiProductDetails>(`/apis/${id}`);
 }
 export function useGetApiProductVersions(id?: string) {
-  return useSwrWithAuth<ApiVersion[]>(`/api-products/${id}/versions`);
+  return useSwrWithAuth<ApiVersion[]>(`/apis/${id}/versions`);
 }
 
 // Subscriptions

--- a/projects/ui/src/Components/ApiProductDetails/ApiProductDetailsPageBody.tsx
+++ b/projects/ui/src/Components/ApiProductDetails/ApiProductDetailsPageBody.tsx
@@ -52,6 +52,7 @@ export function ApiProductDetailsPageBody({
   if (!selectedApiVersion) {
     return null;
   }
+  const includesDocumentation = !!selectedApiVersion.documentation;
   return (
     <ContentWidthDiv pageContentIsWide={true}>
       <Tabs value={tab} onTabChange={(v) => setTab(v ?? defaultTabValue)}>
@@ -61,7 +62,9 @@ export function ApiProductDetailsPageBody({
         */}
         <Tabs.List>
           <Tabs.Tab value={apiProductDetailsTabValues.SPEC}>Spec</Tabs.Tab>
-          <Tabs.Tab value={apiProductDetailsTabValues.DOCS}>Docs</Tabs.Tab>
+          {includesDocumentation && (
+            <Tabs.Tab value={apiProductDetailsTabValues.DOCS}>Docs</Tabs.Tab>
+          )}
         </Tabs.List>
         {/*
           
@@ -75,9 +78,11 @@ export function ApiProductDetailsPageBody({
             selectedApiVersion={selectedApiVersion}
           />
         </Tabs.Panel>
-        <Tabs.Panel value={apiProductDetailsTabValues.DOCS} pt={"xl"}>
-          <DocsTabContent selectedApiVersion={selectedApiVersion} />
-        </Tabs.Panel>
+        {includesDocumentation && (
+          <Tabs.Panel value={apiProductDetailsTabValues.DOCS} pt={"xl"}>
+            <DocsTabContent selectedApiVersion={selectedApiVersion} />
+          </Tabs.Panel>
+        )}
       </Tabs>
     </ContentWidthDiv>
   );

--- a/projects/ui/src/Components/ApiProductDetails/ApiProductDetailsPageHeading.tsx
+++ b/projects/ui/src/Components/ApiProductDetails/ApiProductDetailsPageHeading.tsx
@@ -1,5 +1,4 @@
 import { Flex, Select } from "@mantine/core";
-import { useContext, useState } from "react";
 import toast from "react-hot-toast";
 import {
   ApiProductDetails,
@@ -7,10 +6,8 @@ import {
   ApiVersionSchema,
 } from "../../Apis/api-types";
 import { Icon } from "../../Assets/Icons";
-import { AuthContext } from "../../Context/AuthContext";
 import { FormModalStyles } from "../../Styles/shared/FormModalStyles";
 import { downloadFile } from "../../Utility/utility";
-import NewSubscriptionModal from "../Apps/Details/Modals/NewSubscriptionModal";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
@@ -29,8 +26,8 @@ const ApiProductDetailsPageHeading = ({
   onSelectedApiVersionChange: (newVersionId: string | null) => void;
   apiVersionSpec: ApiVersionSchema | undefined;
 }) => {
-  const { isLoggedIn } = useContext(AuthContext);
-  const [showSubscribeModal, setShowSubscribeModal] = useState(false);
+  // const { isLoggedIn } = useContext(AuthContext);
+  // const [showSubscribeModal, setShowSubscribeModal] = useState(false);
 
   const downloadApiSpec = () => {
     if (!selectedApiVersion?.apiSpec) {
@@ -92,11 +89,14 @@ const ApiProductDetailsPageHeading = ({
                   />
                 </FormModalStyles.InputContainer>
               )}
+              {/* 
+              // Note: Removing sections for GGv2 demo.
+
               {isLoggedIn && (
                 <Button onClick={() => setShowSubscribeModal(true)}>
                   SUBSCRIBE
                 </Button>
-              )}
+              )} */}
               <Button
                 disabled={!selectedApiVersion.apiSpec}
                 onClick={downloadApiSpec}
@@ -104,11 +104,13 @@ const ApiProductDetailsPageHeading = ({
                 DOWNLOAD SPEC
               </Button>
             </Flex>
+            {/*
+            // Note: Removing sections for GGv2 demo.
             <NewSubscriptionModal
               opened={showSubscribeModal}
               onClose={() => setShowSubscribeModal(false)}
               apiProduct={apiProduct}
-            />
+            /> */}
           </Styles.ApiDetailsHeaderAddition>
         ) : undefined
       }

--- a/projects/ui/src/Components/Apis/ApisPage.tsx
+++ b/projects/ui/src/Components/Apis/ApisPage.tsx
@@ -1,24 +1,17 @@
-import { Box, Flex, Loader, Tabs } from "@mantine/core";
+import { Box, Tabs } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { di } from "react-magnetic-di";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  SubscriptionStatus,
-  isSubscriptionsListError,
-} from "../../Apis/api-types";
 import {
   useListApiProducts,
   useListSubscriptionsForStatus,
 } from "../../Apis/hooks";
 import { Icon } from "../../Assets/Icons";
-import { colors } from "../../Styles";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Loading } from "../Common/Loading";
 import { PageContainer } from "../Common/PageContainer";
-import { ApisPageStyles } from "./ApisPage.style";
 import { ApisTabContent } from "./ApisTab/ApisTabContent";
-import PendingSubscriptionsTabContent from "./PendingSubscriptionsTab/PendingSubscriptionsTabContent";
 
 const URL_SEARCH_PARAM_TAB_KEY = "tab";
 const tabValues = {
@@ -30,16 +23,20 @@ const defaultTabValue = tabValues.APIS;
 export function ApisPage() {
   di(useListApiProducts, useListSubscriptionsForStatus);
   const { isLoading: isLoadingApiProducts } = useListApiProducts();
-  const {
-    isLoading: isLoadingSubscriptions,
-    data: subscriptions,
-    error: subscriptionsErr,
-  } = useListSubscriptionsForStatus(SubscriptionStatus.PENDING);
-  const subscriptionsError =
-    !!subscriptionsErr ||
-    isSubscriptionsListError(subscriptions) ||
-    !Array.isArray(subscriptions);
-  const isLoading = isLoadingApiProducts || isLoadingSubscriptions;
+
+  // Note: Removing sections for GGv2 demo.
+
+  // const {
+  //   isLoading: isLoadingSubscriptions,
+  //   data: subscriptions,
+  //   error: subscriptionsErr,
+  // } = useListSubscriptionsForStatus(SubscriptionStatus.PENDING);
+  // const subscriptionsError =
+  //   !!subscriptionsErr ||
+  //   isSubscriptionsListError(subscriptions) ||
+  //   !Array.isArray(subscriptions);
+  // const isLoading = isLoadingApiProducts || isLoadingSubscriptions;
+  const isLoading = isLoadingApiProducts;
 
   //
   // Tab navigation
@@ -78,10 +75,10 @@ export function ApisPage() {
         {isLoading ? (
           // Make sure the APIs are finished loading since they are a dependency of both tabs.
           <Loading message="Getting list of apis..." />
-        ) : subscriptionsError ? (
-          // If there was a subscriptions error message, don't show the subscriptions.
-          <ApisTabContent />
         ) : (
+          // ) : subscriptionsError ? (
+          //   // If there was a subscriptions error message, don't show the subscriptions.
+          //   <ApisTabContent />
           <Tabs value={tab} onTabChange={(t) => setTab(t ?? defaultTabValue)}>
             {/*
           
@@ -89,7 +86,7 @@ export function ApisPage() {
             */}
             <Tabs.List>
               <Tabs.Tab value={tabValues.APIS}>APIs</Tabs.Tab>
-              <Tabs.Tab value={tabValues.SUBS}>
+              {/* <Tabs.Tab value={tabValues.SUBS}>
                 <Flex align="center" justify="center" gap={10}>
                   <span>Pending API Subscriptions</span>
                   {isLoadingSubscriptions || !subscriptions ? (
@@ -104,7 +101,7 @@ export function ApisPage() {
                     )
                   )}
                 </Flex>
-              </Tabs.Tab>
+              </Tabs.Tab> */}
             </Tabs.List>
             {/*
           
@@ -113,12 +110,13 @@ export function ApisPage() {
             <Tabs.Panel value={tabValues.APIS} pt={"xl"}>
               <ApisTabContent />
             </Tabs.Panel>
-            <Tabs.Panel value={tabValues.SUBS} pt={"xl"}>
+            {/* <Tabs.Panel value={tabValues.SUBS} pt={"xl"}>
               <PendingSubscriptionsTabContent
                 subscriptions={subscriptions}
                 isLoadingSubscriptions={isLoadingSubscriptions}
-              />
+              /> 
             </Tabs.Panel>
+            */}
           </Tabs>
         )}
       </Box>

--- a/projects/ui/src/Components/Apis/ApisPage.tsx
+++ b/projects/ui/src/Components/Apis/ApisPage.tsx
@@ -1,28 +1,20 @@
-import { Box, Tabs } from "@mantine/core";
-import { useEffect, useState } from "react";
-import { di } from "react-magnetic-di";
-import { useLocation, useNavigate } from "react-router-dom";
-import {
-  useListApiProducts,
-  useListSubscriptionsForStatus,
-} from "../../Apis/hooks";
+import { Box } from "@mantine/core";
 import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
-import { Loading } from "../Common/Loading";
 import { PageContainer } from "../Common/PageContainer";
 import { ApisTabContent } from "./ApisTab/ApisTabContent";
 
-const URL_SEARCH_PARAM_TAB_KEY = "tab";
-const tabValues = {
-  APIS: "apis",
-  SUBS: "subs",
-};
-const defaultTabValue = tabValues.APIS;
+// const URL_SEARCH_PARAM_TAB_KEY = "tab";
+// const tabValues = {
+//   APIS: "apis",
+//   SUBS: "subs",
+// };
+// const defaultTabValue = tabValues.APIS;
 
 export function ApisPage() {
-  di(useListApiProducts, useListSubscriptionsForStatus);
-  const { isLoading: isLoadingApiProducts } = useListApiProducts();
+  // di(useListApiProducts, useListSubscriptionsForStatus);
+  // const { isLoading: isLoadingApiProducts } = useListApiProducts();
 
   // Note: Removing sections for GGv2 demo.
 
@@ -36,27 +28,27 @@ export function ApisPage() {
   //   isSubscriptionsListError(subscriptions) ||
   //   !Array.isArray(subscriptions);
   // const isLoading = isLoadingApiProducts || isLoadingSubscriptions;
-  const isLoading = isLoadingApiProducts;
+  // const isLoading = isLoadingApiProducts;
 
   //
   // Tab navigation
   //
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [tab, setTab] = useState(
-    new URLSearchParams(location.search).get(URL_SEARCH_PARAM_TAB_KEY) ??
-      defaultTabValue
-  );
-  // Update the URL when the selected tab changes.
-  useEffect(() => {
-    const newSearchParams = new URLSearchParams(location.search);
-    if (!!tab) {
-      newSearchParams.set(URL_SEARCH_PARAM_TAB_KEY, tab);
-    }
-    navigate(location.pathname + `?${newSearchParams.toString()}`, {
-      replace: true,
-    });
-  }, [tab, location.search]);
+  // const navigate = useNavigate();
+  // const location = useLocation();
+  // const [tab, setTab] = useState(
+  //   new URLSearchParams(location.search).get(URL_SEARCH_PARAM_TAB_KEY) ??
+  //     defaultTabValue
+  // );
+  // // Update the URL when the selected tab changes.
+  // useEffect(() => {
+  //   const newSearchParams = new URLSearchParams(location.search);
+  //   if (!!tab) {
+  //     newSearchParams.set(URL_SEARCH_PARAM_TAB_KEY, tab);
+  //   }
+  //   navigate(location.pathname + `?${newSearchParams.toString()}`, {
+  //     replace: true,
+  //   });
+  // }, [tab, location.search]);
 
   //
   // Render
@@ -72,21 +64,22 @@ export function ApisPage() {
       />
 
       <Box px={30} mb={60}>
-        {isLoading ? (
+        {/* {isLoading ? (
           // Make sure the APIs are finished loading since they are a dependency of both tabs.
           <Loading message="Getting list of apis..." />
-        ) : (
-          // ) : subscriptionsError ? (
+        ) : ( 
+          ) : subscriptionsError ? (
           //   // If there was a subscriptions error message, don't show the subscriptions.
-          //   <ApisTabContent />
-          <Tabs value={tab} onTabChange={(t) => setTab(t ?? defaultTabValue)}>
+*/}
+        <ApisTabContent />
+        {/* <Tabs value={tab} onTabChange={(t) => setTab(t ?? defaultTabValue)}>
             {/*
           
             Tab Titles
-            */}
+            * /}
             <Tabs.List>
               <Tabs.Tab value={tabValues.APIS}>APIs</Tabs.Tab>
-              {/* <Tabs.Tab value={tabValues.SUBS}>
+               <Tabs.Tab value={tabValues.SUBS}>
                 <Flex align="center" justify="center" gap={10}>
                   <span>Pending API Subscriptions</span>
                   {isLoadingSubscriptions || !subscriptions ? (
@@ -101,24 +94,24 @@ export function ApisPage() {
                     )
                   )}
                 </Flex>
-              </Tabs.Tab> */}
+              </Tabs.Tab> 
             </Tabs.List>
             {/*
           
             Tab Content
-            */}
-            <Tabs.Panel value={tabValues.APIS} pt={"xl"}>
-              <ApisTabContent />
-            </Tabs.Panel>
-            {/* <Tabs.Panel value={tabValues.SUBS} pt={"xl"}>
+            * /}
+        <Tabs.Panel value={tabValues.APIS} pt={"xl"}>
+          <ApisTabContent />
+        </Tabs.Panel>
+        {/* <Tabs.Panel value={tabValues.SUBS} pt={"xl"}>
               <PendingSubscriptionsTabContent
                 subscriptions={subscriptions}
                 isLoadingSubscriptions={isLoadingSubscriptions}
               /> 
             </Tabs.Panel>
-            */}
-          </Tabs>
-        )}
+            * /}
+          </Tabs> 
+        )}*/}
       </Box>
     </PageContainer>
   );

--- a/projects/ui/src/Components/Apis/ApisTab/ApisList.tsx
+++ b/projects/ui/src/Components/Apis/ApisTab/ApisList.tsx
@@ -16,7 +16,7 @@ export function ApisList({
   nameFilter: string;
 }) {
   const { preferGridView } = useContext(AppContext);
-  const { isLoading, data: apiProductsList } = useListApiProducts();
+  const { data: apiProductsList } = useListApiProducts();
 
   //
   // Filter the list of api products.
@@ -64,7 +64,9 @@ export function ApisList({
   //
   // Render
   //
-  if (isLoading) {
+  // The SWR loading check causes the page to flicker when it's loading, even if it's just re-fetching.
+  // This alternative removes flickering, but causes the loading wheel to persist.
+  if (apiProductsList === undefined) {
     return <Loading message="Getting list of apis..." />;
   }
   if (!filteredApiProductsList.length) {

--- a/projects/ui/src/Components/AppContentRoutes.tsx
+++ b/projects/ui/src/Components/AppContentRoutes.tsx
@@ -4,18 +4,18 @@ import {
   oidcAuthCodeConfigCallbackPath,
   oidcAuthCodeConfigLogoutPath,
 } from "../user_variables.tmplr";
-import AdminSubscriptionsPage from "./AdminSubscriptions/AdminSubscriptionsPage";
-import AdminTeamsPage from "./AdminTeams/AdminTeamsPage";
 import { ApiProductDetailsPage } from "./ApiProductDetails/ApiProductDetailsPage";
 import { ApisPage } from "./Apis/ApisPage";
-import { AppsPage } from "./Apps/AppsPage";
-import AppDetailsPage from "./Apps/Details/AppDetailsPage";
 import { ErrorBoundary } from "./Common/ErrorBoundary";
 import LoggedOut from "./Common/LoggedOut";
 import { HomePage } from "./Home/HomePage";
 import { Footer } from "./Structure/Footer";
-import TeamDetailsPage from "./Teams/Details/TeamDetailsPage";
-import { TeamsPage } from "./Teams/TeamsPage";
+// import AdminSubscriptionsPage from "./AdminSubscriptions/AdminSubscriptionsPage";
+// import AdminTeamsPage from "./AdminTeams/AdminTeamsPage";
+// import { AppsPage } from "./Apps/AppsPage";
+// import AppDetailsPage from "./Apps/Details/AppDetailsPage";
+// import TeamDetailsPage from "./Teams/Details/TeamDetailsPage";
+// import { TeamsPage } from "./Teams/TeamsPage";
 
 const MainContentContainer = styled.div`
   grid-area: contentcontainer;
@@ -82,6 +82,7 @@ function AppContentRoutes() {
             </ErrorBoundary>
           }
         />
+        {/* // Note: Removing sections for GGv2 demo.
         <Route
           path="/apps"
           element={
@@ -113,11 +114,11 @@ function AppContentRoutes() {
               <TeamDetailsPage />
             </ErrorBoundary>
           }
-        />
+        /> 
         {/*
         
         // Admin Routes
-        */}
+        * /}
         <Route
           path="/admin/subscriptions"
           element={
@@ -133,7 +134,7 @@ function AppContentRoutes() {
               <AdminTeamsPage />
             </ErrorBoundary>
           }
-        />
+        />*/}
       </Routes>
 
       <Footer />

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -21,36 +21,40 @@ if (!window.isSecureContext) {
  **/
 export function Header() {
   const routerLocation = useLocation();
-  const { isLoggedIn, isAdmin } = useContext(AuthContext);
+  const { isLoggedIn } = useContext(AuthContext);
 
   const inArea = (paths: string[]) => {
     return paths.some((s) => routerLocation.pathname.includes(s));
   };
 
-  const inAdminTeamsArea = useMemo(
-    () => inArea(["/admin/teams"]),
-    [routerLocation.pathname]
-  );
+  // Note: Removing sections for GGv2 demo.
 
-  const inAdminSubscriptionsArea = useMemo(
-    () => inArea(["/admin/subscriptions"]),
-    [routerLocation.pathname]
-  );
+  // const inAdminTeamsArea = useMemo(
+  //   () => inArea(["/admin/teams"]),
+  //   [routerLocation.pathname]
+  // );
+
+  // const inAdminSubscriptionsArea = useMemo(
+  //   () => inArea(["/admin/subscriptions"]),
+  //   [routerLocation.pathname]
+  // );
 
   const inAPIsArea = useMemo(
     () => inArea(["/apis", "/api-details/"]),
     [routerLocation.pathname]
   );
 
-  const inAppsArea = useMemo(
-    () => inArea(["/apps", "/app-details/"]),
-    [routerLocation.pathname]
-  );
+  // Note: Removing sections for GGv2 demo.
 
-  const inTeamsArea = useMemo(
-    () => inArea(["/teams", "/team-details/"]),
-    [routerLocation.pathname]
-  );
+  // const inAppsArea = useMemo(
+  //   () => inArea(["/apps", "/app-details/"]),
+  //   [routerLocation.pathname]
+  // );
+
+  // const inTeamsArea = useMemo(
+  //   () => inArea(["/teams", "/team-details/"]),
+  //   [routerLocation.pathname]
+  // );
 
   const { pageContentIsWide } = useContext(AppContext);
 
@@ -66,6 +70,10 @@ export function Header() {
           <NavLink to={"/"} className={"navLink"} end>
             Home
           </NavLink>
+
+          {/*
+          // Note: Removing sections for GGv2 demo.
+
           {!isAdmin && (
             // If we allow admins to access the APIs page, things get a bit
             // more confusing, since we will have to consider the behavior
@@ -73,13 +81,19 @@ export function Header() {
             // For example, a user can create an App from the API details page,
             // so it would be strange for the admin not to have access to
             // the Apps page in that case.
-            <NavLink
-              to={"/apis"}
-              className={`navLink ${inAPIsArea ? "active" : ""}`}
-            >
-              APIs
-            </NavLink>
-          )}
+          */}
+          <NavLink
+            to={"/apis"}
+            className={`navLink ${inAPIsArea ? "active" : ""}`}
+          >
+            APIs
+          </NavLink>
+          {/* )} */}
+
+          {/* 
+
+          // Note: Removing sections for GGv2 demo.
+
           {isLoggedIn &&
             (isAdmin ? (
               //
@@ -120,6 +134,7 @@ export function Header() {
                 </NavLink>
               </>
             ))}
+            */}
 
           <div className="divider" />
           <ErrorBoundary fallback="Access issues" class="horizontalError">

--- a/projects/ui/vite.config.ts
+++ b/projects/ui/vite.config.ts
@@ -14,7 +14,4 @@ export default defineConfig({
     eslint(),
     svgr(),
   ],
-  define: {
-    global: {},
-  },
 });

--- a/projects/ui/vite.config.ts
+++ b/projects/ui/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
     eslint(),
     svgr(),
   ],
+  define: {
+    global: {},
+  },
 });


### PR DESCRIPTION
This PR:
- Comments out the sections of the feature branch which are not currently in Gloo Gateway. This hides the:
  - Teams pages
  - Subscriptions pages
  - Admin features
- Makes it so there is no different Admin view now.
- Hides the documentation tab on the API details page if there is no API version documentation.
- Fixes a bug with the API's page flickering when loading.

Here is a video demo of the site working with [the Gloo Gateway (GGv2) version of the portal server](https://github.com/solo-io/solo-projects/blob/main/codegen/portal/v1/openapi.yaml). The API's are public, and I didn't do anything special to set up authentication, it's just using Keycloak auth.
- Edit: I was able to get the `/me` auth endpoint working in my second comment below.

https://github.com/solo-io/dev-portal-starter/assets/4720646/8f075613-335b-4815-8346-fe7ec4ef5184


