### PR TITLE
test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ clean:
 install-tools: update-ui-deps
 
 # test
+# test 2
 .PHONY: update-ui-deps
 update-ui-deps:
 	yarn --cwd=$(UI_ROOT_DIR) --prefer-offline install

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ clean:
 .PHONY: install-tools
 install-tools: update-ui-deps
 
+# test
 .PHONY: update-ui-deps
 update-ui-deps:
 	yarn --cwd=$(UI_ROOT_DIR) --prefer-offline install


### PR DESCRIPTION
On first PR, cache is not found:

If PR check fails, the results are not cached.
<img width="1261" alt="Screenshot 2024-07-11 at 1 35 40 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/3acd90fa-5f53-4106-8c2b-08e5067fe421">

But if it passes, the cache is saved and used in subsequent workflow runs - in this case it saved 31 seconds.

<img width="1261" alt="Screenshot 2024-07-11 at 1 33 11 PM" src="https://github.com/solo-io/dev-portal-starter/assets/4720646/6a86b405-fbf1-4f81-8888-2f109130e736">
