### PR TITLE
Removed OpenAPI labels and now filtering out the imageURL from the metadata

### DIFF
--- a/projects/ui/src/Components/ApiDetails/gloo-gateway-components/ApiProductDetailsPageHeading.tsx
+++ b/projects/ui/src/Components/ApiDetails/gloo-gateway-components/ApiProductDetailsPageHeading.tsx
@@ -8,7 +8,10 @@ import {
 import { Icon } from "../../../Assets/Icons";
 import { FormModalStyles } from "../../../Styles/shared/FormModalStyles";
 import { useGetImageURL } from "../../../Utility/custom-image-utility";
-import { downloadFile } from "../../../Utility/utility";
+import {
+  downloadFile,
+  filterMetadataToDisplay,
+} from "../../../Utility/utility";
 import { BannerHeading } from "../../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
 import { Button } from "../../Common/Button";
@@ -78,9 +81,9 @@ const ApiProductDetailsPageHeading = ({
                   Operations
                 </Styles.ApiDetailsExtraInfo>
               )}
-              <Styles.ApiDetailsExtraInfo>
+              {/* <Styles.ApiDetailsExtraInfo>
                 <Icon.OpenApiIcon /> OpenAPI
-              </Styles.ApiDetailsExtraInfo>
+              </Styles.ApiDetailsExtraInfo> */}
             </Flex>
             <Flex gap="10px" align={"center"} sx={{ flexWrap: "wrap" }}>
               {apiProductVersions.length > 0 && (
@@ -117,15 +120,15 @@ const ApiProductDetailsPageHeading = ({
             {selectedApiVersion.productVersionMetadata && (
               <Box mt={"5px"} sx={{ flexBasis: "100%" }}>
                 <DataPairPillList className="metadataList">
-                  {Object.entries(
-                    selectedApiVersion.productVersionMetadata
-                  ).map(([pairKey, pairValue], idx) => (
-                    <DataPairPill
-                      key={idx}
-                      pairKey={pairKey}
-                      value={pairValue}
-                    />
-                  ))}
+                  {Object.entries(selectedApiVersion.productVersionMetadata)
+                    .filter(filterMetadataToDisplay)
+                    .map(([pairKey, pairValue], idx) => (
+                      <DataPairPill
+                        key={idx}
+                        pairKey={pairKey}
+                        value={pairValue}
+                      />
+                    ))}
                 </DataPairPillList>
               </Box>
             )}

--- a/projects/ui/src/Components/ApiDetails/gloo-mesh-gateway-components/GMG_ApiDetailsPage.tsx
+++ b/projects/ui/src/Components/ApiDetails/gloo-mesh-gateway-components/GMG_ApiDetailsPage.tsx
@@ -48,9 +48,9 @@ function HeaderSummary({ apiSchema }: { apiSchema: ApiVersionSchema }) {
       <ApiDetailsExtraInfo>
         <Icon.HtmlTag /> {Object.keys(apiSchema.paths).length} Operations
       </ApiDetailsExtraInfo>
-      <ApiDetailsExtraInfo>
+      {/* <ApiDetailsExtraInfo>
         <Icon.OpenApiIcon /> OpenAPI
-      </ApiDetailsExtraInfo>
+      </ApiDetailsExtraInfo> */}
     </ApiDetailsHeaderAddition>
   );
 }

--- a/projects/ui/src/Components/Apis/gloo-gateway-components/ApisTab/ApiSummaryCards/ApiSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apis/gloo-gateway-components/ApisTab/ApiSummaryCards/ApiSummaryGridCard.tsx
@@ -1,10 +1,9 @@
 import { Box } from "@mantine/core";
 import { ApiProductSummary } from "../../../../../Apis/api-types";
-import { Icon } from "../../../../../Assets/Icons";
-import { CardStyles } from "../../../../../Styles/shared/Card.style";
 import { GridCardStyles } from "../../../../../Styles/shared/GridCard.style";
 import { useGetImageURL } from "../../../../../Utility/custom-image-utility";
 import { getApiProductDetailsSpecTabLink } from "../../../../../Utility/link-builders";
+import { filterMetadataToDisplay } from "../../../../../Utility/utility";
 import {
   DataPairPill,
   DataPairPillList,
@@ -39,21 +38,21 @@ export function ApiSummaryGridCard({
         {!!apiProduct.apiProductMetadata && (
           <Box pt={"15px"}>
             <DataPairPillList className="metadataList">
-              {Object.entries(apiProduct.apiProductMetadata).map(
-                ([pairKey, pairValue], idx) => (
+              {Object.entries(apiProduct.apiProductMetadata)
+                .filter(filterMetadataToDisplay)
+                .map(([pairKey, pairValue], idx) => (
                   <DataPairPill key={idx} pairKey={pairKey} value={pairValue} />
-                )
-              )}
+                ))}
             </DataPairPillList>
           </Box>
         )}
       </Box>
-      <GridCardStyles.Footer>
+      {/* <GridCardStyles.Footer>
         <CardStyles.MetaInfo>
           <Icon.SmallCodeGear />
           <CardStyles.SecondaryInfo>OpenAPI</CardStyles.SecondaryInfo>
         </CardStyles.MetaInfo>
-      </GridCardStyles.Footer>
+      </GridCardStyles.Footer> */}
     </GridCardStyles.GridCardWithLink>
   );
 }

--- a/projects/ui/src/Components/Apis/gloo-gateway-components/ApisTab/ApiSummaryCards/ApiSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apis/gloo-gateway-components/ApisTab/ApiSummaryCards/ApiSummaryListCard.tsx
@@ -1,11 +1,11 @@
 import { Box, Flex, Text } from "@mantine/core";
 import { NavLink } from "react-router-dom";
 import { ApiProductSummary } from "../../../../../Apis/api-types";
-import { Icon } from "../../../../../Assets/Icons";
 import { CardStyles } from "../../../../../Styles/shared/Card.style";
 import { ListCardStyles } from "../../../../../Styles/shared/ListCard.style";
 import { useGetImageURL } from "../../../../../Utility/custom-image-utility";
 import { getApiProductDetailsSpecTabLink } from "../../../../../Utility/link-builders";
+import { filterMetadataToDisplay } from "../../../../../Utility/utility";
 import {
   DataPairPill,
   DataPairPillList,
@@ -37,21 +37,21 @@ export function ApiSummaryListCard({
             {!!apiProduct.apiProductMetadata && (
               <Box pt={"5px"}>
                 <DataPairPillList className="metadataList">
-                  {Object.entries(apiProduct.apiProductMetadata).map(
-                    ([pairKey, pairValue], idx) => (
+                  {Object.entries(apiProduct.apiProductMetadata)
+                    .filter(filterMetadataToDisplay)
+                    .map(([pairKey, pairValue], idx) => (
                       <DataPairPill
                         key={idx}
                         pairKey={pairKey}
                         value={pairValue}
                       />
-                    )
-                  )}
+                    ))}
                 </DataPairPillList>
               </Box>
             )}
           </Box>
         </Flex>
-        <ListCardStyles.Footer>
+        {/* <ListCardStyles.Footer>
           <CardStyles.MetaInfo>
             <Icon.SmallCodeGear />
             <CardStyles.SecondaryInfo>OpenAPI</CardStyles.SecondaryInfo>
@@ -59,7 +59,7 @@ export function ApiSummaryListCard({
           <ListCardStyles.TypeIcon>
             <Icon.OpenApiIcon />
           </ListCardStyles.TypeIcon>
-        </ListCardStyles.Footer>
+        </ListCardStyles.Footer> */}
       </ListCardStyles.ListCardWithLink>
     </NavLink>
   );

--- a/projects/ui/src/Components/Apis/gloo-mesh-gateway-components/ApiSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apis/gloo-mesh-gateway-components/ApiSummaryGridCard.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from "react-router-dom";
 import { API } from "../../../Apis/api-types";
-import { Icon } from "../../../Assets/Icons";
 import { useGetImageURL } from "../../../Utility/custom-image-utility";
+import { filterMetadataToDisplay } from "../../../Utility/utility";
 import { DataPairPill, DataPairPillList } from "../../Common/DataPairPill";
 
 /**
@@ -33,21 +33,21 @@ export function ApiSummaryGridCard({ api }: { api: API }) {
             <div className="description">{api.description}</div>
             {api.customMetadata && (
               <DataPairPillList className="metadataList">
-                {Object.entries(api.customMetadata).map(
-                  ([pairKey, pairValue], idx) => (
+                {Object.entries(api.customMetadata)
+                  .filter(filterMetadataToDisplay)
+                  .map(([pairKey, pairValue], idx) => (
                     <DataPairPill
                       key={idx}
                       pairKey={pairKey}
                       value={pairValue}
                     />
-                  )
-                )}
+                  ))}
               </DataPairPillList>
             )}
           </div>
         </div>
       </div>
-      <div className="footer">
+      {/* <div className="footer">
         <div className="metaInfo">
           <Icon.SmallCodeGear />
           <div className="typeTitle" aria-label="API Type">
@@ -57,7 +57,7 @@ export function ApiSummaryGridCard({ api }: { api: API }) {
         <div className="typeIcon">
           <Icon.OpenApiIcon />
         </div>
-      </div>
+      </div> */}
     </NavLink>
   );
 }

--- a/projects/ui/src/Components/Apis/gloo-mesh-gateway-components/ApiSummaryListCard.tsx
+++ b/projects/ui/src/Components/Apis/gloo-mesh-gateway-components/ApiSummaryListCard.tsx
@@ -1,8 +1,8 @@
 import { NavLink } from "react-router-dom";
 import { API } from "../../../Apis/api-types";
-import { Icon } from "../../../Assets/Icons";
 import { ListCardStyles } from "../../../Styles/shared/ListCard.style";
 import { useGetImageURL } from "../../../Utility/custom-image-utility";
+import { filterMetadataToDisplay } from "../../../Utility/utility";
 import { DataPairPill, DataPairPillList } from "../../Common/DataPairPill";
 
 /**
@@ -36,21 +36,21 @@ export function ApiSummaryListCard({ api }: { api: API }) {
               <div className="description">{api.description}</div>
               {api.customMetadata && (
                 <DataPairPillList className="metadataList">
-                  {Object.entries(api.customMetadata).map(
-                    ([pairKey, pairValue], idx) => (
+                  {Object.entries(api.customMetadata)
+                    .filter(filterMetadataToDisplay)
+                    .map(([pairKey, pairValue], idx) => (
                       <DataPairPill
                         key={idx}
                         pairKey={pairKey}
                         value={pairValue}
                       />
-                    )
-                  )}
+                    ))}
                 </DataPairPillList>
               )}
             </div>
           </div>
         </div>
-        <div className="footer">
+        {/* <div className="footer">
           <div className="metaInfo">
             <Icon.SmallCodeGear />
             <div className="typeTitle" aria-label="API Type">
@@ -60,7 +60,7 @@ export function ApiSummaryListCard({ api }: { api: API }) {
           <div className="typeIcon">
             <Icon.OpenApiIcon />
           </div>
-        </div>
+        </div> */}
       </div>
     </NavLink>
   );

--- a/projects/ui/src/Components/UsagePlans/UsagePlanList/APIUsagePlanCard.tsx
+++ b/projects/ui/src/Components/UsagePlans/UsagePlanList/APIUsagePlanCard.tsx
@@ -117,7 +117,7 @@ export function APIUsagePlanCard({ api }: { api: API }) {
         </div>
       )}
 
-      <div className="apiFooter">
+      {/* <div className="apiFooter">
         <div className="metaInfo">
           <Icon.SmallCodeGear />
           <div className="typeTitle" aria-label="API Type">
@@ -127,7 +127,7 @@ export function APIUsagePlanCard({ api }: { api: API }) {
         <div className="typeIcon">
           <Icon.OpenApiIcon />
         </div>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/projects/ui/src/Utility/utility.ts
+++ b/projects/ui/src/Utility/utility.ts
@@ -118,3 +118,8 @@ export const customLog = (...args: Parameters<typeof console.log>) => {
     console.log(...args);
   }
 };
+
+export const filterMetadataToDisplay = ([pairKey]: [
+  key: string,
+  value: string
+]) => pairKey !== "imageURL";


### PR DESCRIPTION
This PR:
- Removes the OpenAPI label.
- Filters out the `imageURL` metadata pairs on the apis and api details pages.

<img width="1382" alt="Screenshot 2024-07-12 at 1 57 21 PM" src="https://github.com/user-attachments/assets/548eb02d-d022-4cbb-b8aa-dffb28f6d021">
<img width="1382" alt="Screenshot 2024-07-12 at 1 57 35 PM" src="https://github.com/user-attachments/assets/2f1ba629-9157-40d6-819c-9324f42f7b16">
<img width="1382" alt="Screenshot 2024-07-12 at 1 57 44 PM" src="https://github.com/user-attachments/assets/e2fb435c-c1fd-4317-9b30-695345a023f3">

Resolves: https://github.com/solo-io/gloo-mesh-enterprise/issues/17765
