### PR TITLE
UI Hotfixes + Tweaks

### DIFF
--- a/changelog/v0.0.36/update-hotfixes-for-gg-portal-demo-build.yaml
+++ b/changelog/v0.0.36/update-hotfixes-for-gg-portal-demo-build.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >-
+      Update metadata endpoint to allow updating of metadata.
+      Updated subscription modal to allow toggling of subscription status by admin.
+      Use a selection dropdown for rate limit units to not allow invalid values.

--- a/changelog/v0.0.36/update-hotfixes-for-gg-portal-demo-build.yaml
+++ b/changelog/v0.0.36/update-hotfixes-for-gg-portal-demo-build.yaml
@@ -1,5 +1,6 @@
 changelog:
   - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7038
     description: >-
       Update metadata endpoint to allow updating of metadata.
       Updated subscription modal to allow toggling of subscription status by admin.

--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -172,16 +172,20 @@ export type OauthCredential = {
 };
 
 // This list of units is used both for the type and for the dropdown in the UI.
-export const rateLimitUnits = [
+const rateLimitUnits = [
   "UNKNOWN",
   "SECOND",
   "MINUTE",
   "HOUR",
   "DAY",
   "MONTH",
-  "YEAR"
+  "YEAR",
 ] as const; // The 'as const' tells TypeScript to treat these as literal types
-export type RateLimitUnit = typeof rateLimitUnits[number];
+export const rateLimitUnitOptions = rateLimitUnits.map((unit) => ({
+  value: unit,
+  label: unit,
+}));
+export type RateLimitUnit = (typeof rateLimitUnits)[number];
 
 export type RateLimit = {
   requestsPerUnit: string;

--- a/projects/ui/src/Apis/api-types.ts
+++ b/projects/ui/src/Apis/api-types.ts
@@ -171,9 +171,21 @@ export type OauthCredential = {
   idpClientName: string;
 };
 
+// This list of units is used both for the type and for the dropdown in the UI.
+export const rateLimitUnits = [
+  "UNKNOWN",
+  "SECOND",
+  "MINUTE",
+  "HOUR",
+  "DAY",
+  "MONTH",
+  "YEAR"
+] as const; // The 'as const' tells TypeScript to treat these as literal types
+export type RateLimitUnit = typeof rateLimitUnits[number];
+
 export type RateLimit = {
   requestsPerUnit: string;
-  unit: string;
+  unit: RateLimitUnit;
 };
 
 export type SubscriptionMetadata = {

--- a/projects/ui/src/Apis/gg_hooks.ts
+++ b/projects/ui/src/Apis/gg_hooks.ts
@@ -523,9 +523,9 @@ export function useCreateUserMutation() {
 }
 
 // -------------------------------- //
-// region (Admin) Create App Metadata
+// region (Admin) Upsert App Metadata
 
-export type CreateUpdateAppMetadataParams = MutationWithArgs<{
+export type UpsertAppMetadataParams = MutationWithArgs<{
   appId: string;
   rateLimit?: RateLimit;
   customMetadata?: Record<string, string>;
@@ -534,10 +534,7 @@ export type CreateUpdateAppMetadataParams = MutationWithArgs<{
 export function useUpsertAppMetadataMutation() {
   const { latestAccessToken } = useContext(AuthContext);
   const { mutate } = useSWRConfig();
-  const fetcher = async (
-    _: string,
-    { arg }: CreateUpdateAppMetadataParams
-  ) => {
+  const fetcher = async (_: string, { arg }: UpsertAppMetadataParams) => {
     const req: Record<string, any> = { appId: arg.appId };
     if (arg.customMetadata !== undefined) {
       req.customMetadata = arg.customMetadata;
@@ -557,9 +554,9 @@ export function useUpsertAppMetadataMutation() {
 }
 
 // -------------------------------- //
-// region (Admin) Create Subscription Metadata
+// region (Admin) Upsert Subscription Metadata
 
-export type CreateUpdateSubscriptionMetadataParams = MutationWithArgs<{
+export type UpsertSubscriptionMetadataParams = MutationWithArgs<{
   subscription: Subscription;
   customMetadata?: Record<string, string>;
   rateLimit?: RateLimit;
@@ -570,7 +567,7 @@ export function useUpsertSubscriptionMetadataMutation() {
   const { mutate } = useSWRConfig();
   const fetcher = async (
     _: string,
-    { arg }: CreateUpdateSubscriptionMetadataParams
+    { arg }: UpsertSubscriptionMetadataParams
   ) => {
     const req: Record<string, any> = { subscriptionId: arg.subscription.id };
     if (arg.customMetadata !== undefined) {

--- a/projects/ui/src/Apis/gg_hooks.ts
+++ b/projects/ui/src/Apis/gg_hooks.ts
@@ -531,10 +531,10 @@ export type CreateUpdateAppMetadataParams = MutationWithArgs<{
   customMetadata?: Record<string, string>;
 }>;
 
-export function useCreateAppMetadataMutation() {
+export function useUpsertAppMetadataMutation() {
   const { latestAccessToken } = useContext(AuthContext);
   const { mutate } = useSWRConfig();
-  const createAppMetadata = async (
+  const fetcher = async (
     _: string,
     { arg }: CreateUpdateAppMetadataParams
   ) => {
@@ -553,32 +553,7 @@ export function useCreateAppMetadataMutation() {
     mutate(TEAM_APPS_SWR_KEY);
     mutate(`/apps/${arg.appId}`);
   };
-  return useSWRMutation(`create-app-metadata`, createAppMetadata);
-}
-
-// -------------------------------- //
-// region (Admin) Update App Metadata
-
-export function useUpdateAppMetadataMutation() {
-  const { latestAccessToken } = useContext(AuthContext);
-  const { mutate } = useSWRConfig();
-  const fetcher = async (_: string, { arg }: CreateUpdateAppMetadataParams) => {
-    const req: Record<string, any> = { appId: arg.appId };
-    if (arg.customMetadata !== undefined) {
-      req.customMetadata = arg.customMetadata;
-    }
-    if (arg.rateLimit !== undefined) {
-      req.rateLimit = arg.rateLimit;
-    }
-    await fetchJSON(`/apps/${arg.appId}/metadata`, {
-      method: "PUT",
-      headers: getLatestAuthHeaders(latestAccessToken),
-      body: JSON.stringify(req),
-    });
-    mutate(TEAM_APPS_SWR_KEY);
-    mutate(`/apps/${arg.appId}`);
-  };
-  return useSWRMutation("update-app-metadata", fetcher);
+  return useSWRMutation(`upsert-app-metadata`, fetcher);
 }
 
 // -------------------------------- //
@@ -590,7 +565,7 @@ export type CreateUpdateSubscriptionMetadataParams = MutationWithArgs<{
   rateLimit?: RateLimit;
 }>;
 
-export function useCreateSubscriptionMetadataMutation() {
+export function useUpsertSubscriptionMetadataMutation() {
   const { latestAccessToken } = useContext(AuthContext);
   const { mutate } = useSWRConfig();
   const fetcher = async (
@@ -616,37 +591,5 @@ export function useCreateSubscriptionMetadataMutation() {
     mutate(`/subscriptions?status=${SubscriptionStatus.PENDING}`);
     mutate(APP_SUBS_SWR_KEY);
   };
-  return useSWRMutation(`create-subscription-metadata`, fetcher);
-}
-
-// -------------------------------- //
-// region (Admin) Update Subscription Metadata
-
-export function useUpdateSubscriptionMetadataMutation() {
-  const { latestAccessToken } = useContext(AuthContext);
-  const { mutate } = useSWRConfig();
-  const fetcher = async (
-    _: string,
-    { arg }: CreateUpdateSubscriptionMetadataParams
-  ) => {
-    const req: Record<string, any> = { subscriptionId: arg.subscription.id };
-    if (arg.customMetadata !== undefined) {
-      req.customMetadata = arg.customMetadata;
-    }
-    if (arg.rateLimit !== undefined) {
-      req.rateLimit = arg.rateLimit;
-    }
-    await fetchJSON(`/subscriptions/${arg.subscription.id}/metadata`, {
-      method: "PUT",
-      headers: getLatestAuthHeaders(latestAccessToken),
-      body: JSON.stringify(req),
-    });
-    // We use several queries to get subscriptions across different pages.
-    // Doing all the mutations here so we don't miss anything.
-    mutate(`/apps/${arg.subscription.applicationId}/subscriptions`);
-    mutate(`/subscriptions?status=${SubscriptionStatus.APPROVED}`);
-    mutate(`/subscriptions?status=${SubscriptionStatus.PENDING}`);
-    mutate(APP_SUBS_SWR_KEY);
-  };
-  return useSWRMutation(`update-subscription-metadata`, fetcher);
+  return useSWRMutation(`upsert-subscription-metadata`, fetcher);
 }

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardAdminFooter.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardAdminFooter.tsx
@@ -19,8 +19,6 @@ const SubscriptionInfoCardAdminFooter = ({
   const [showRejectSubModal, setShowRejectSubModal] = useState(false);
   const [showDeleteSubModal, setShowDeleteSubModal] = useState(false);
 
-  const canApproveRejectSubscription =
-    subscriptionState === SubscriptionState.PENDING;
   const canDeleteSubscription = subscriptionState !== SubscriptionState.DELETED;
 
   //
@@ -34,7 +32,7 @@ const SubscriptionInfoCardAdminFooter = ({
             <Button
               color="success"
               size="xs"
-              disabled={!canApproveRejectSubscription}
+              disabled={subscriptionState === SubscriptionState.APPROVED}
               onClick={() => setShowApproveSubModal(true)}
             >
               Approve
@@ -43,13 +41,13 @@ const SubscriptionInfoCardAdminFooter = ({
             <Button
               color="warning"
               size="xs"
-              disabled={!canApproveRejectSubscription}
+              disabled={subscriptionState === SubscriptionState.REJECTED}
               onClick={() => setShowRejectSubModal(true)}
             >
               Reject
             </Button>
 
-            <Button
+            <Button  // TODO: Verify with JM, but if admins can't join teams, then there's no need for the deletion button, because only team members can delete.
               color="danger"
               size="xs"
               disabled={!canDeleteSubscription}

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardAdminFooter.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardAdminFooter.tsx
@@ -47,7 +47,7 @@ const SubscriptionInfoCardAdminFooter = ({
               Reject
             </Button>
 
-            <Button  // TODO: Verify with JM, but if admins can't join teams, then there's no need for the deletion button, because only team members can delete.
+            <Button
               color="danger"
               size="xs"
               disabled={!canDeleteSubscription}

--- a/projects/ui/src/Utility/AdminUtility/CustomMetadataEditor.tsx
+++ b/projects/ui/src/Utility/AdminUtility/CustomMetadataEditor.tsx
@@ -4,10 +4,8 @@ import toast from "react-hot-toast";
 import {
   CreateUpdateAppMetadataParams,
   CreateUpdateSubscriptionMetadataParams,
-  useCreateAppMetadataMutation,
-  useCreateSubscriptionMetadataMutation,
-  useUpdateAppMetadataMutation,
-  useUpdateSubscriptionMetadataMutation,
+  useUpsertAppMetadataMutation,
+  useUpsertSubscriptionMetadataMutation,
 } from "../../Apis/gg_hooks";
 import { Icon } from "../../Assets/Icons";
 import { Button } from "../../Components/Common/Button";
@@ -49,12 +47,9 @@ export const CustomMetadataEditor = ({
   //
   //  region Saving Data
   //
-  const { trigger: createAppMetadata } = useCreateAppMetadataMutation();
-  const { trigger: updateAppMetadata } = useUpdateAppMetadataMutation();
-  const { trigger: createSubscriptionMetadata } =
-    useCreateSubscriptionMetadataMutation();
-  const { trigger: updateSubscriptionMetadata } =
-    useUpdateSubscriptionMetadataMutation();
+  const { trigger: upsertAppMetadata } = useUpsertAppMetadataMutation();
+  const { trigger: upsertSubscriptionMetadata } =
+    useUpsertSubscriptionMetadataMutation();
   const onSave = async () => {
     // Stop here if the object wasn't edited.
     if (shallowEquals(editedCustomMetadata, customMetadata)) {
@@ -68,16 +63,17 @@ export const CustomMetadataEditor = ({
           rateLimit: rateLimitInfo,
           subscription: item,
         };
+        // using the same upsert operation but in different contexts to better display the warning messages based on the context of the call
         if (!!item.metadata) {
           // Updating existing metadata
-          await toast.promise(updateSubscriptionMetadata(payload), {
+          await toast.promise(upsertSubscriptionMetadata(payload), {
             error: "There was an error updating the subscription metadata.",
             loading: "Updating the subscription metadata.",
             success: "Updated the subscription metadata!",
           });
         } else {
           // Creating metadata
-          await toast.promise(createSubscriptionMetadata(payload), {
+          await toast.promise(upsertSubscriptionMetadata(payload), {
             error: "There was an error creating the subscription metadata.",
             loading: "Creating the subscription metadata.",
             success: "Created the subscription metadata!",
@@ -92,14 +88,14 @@ export const CustomMetadataEditor = ({
         };
         if (!!item.metadata) {
           // Updating existing metadata
-          await toast.promise(updateAppMetadata(payload), {
+          await toast.promise(upsertAppMetadata(payload), {
             error: "There was an error updating the app metadata.",
             loading: "Updating the app metadata.",
             success: "Updated the app metadata!",
           });
         } else {
           // Creating metadata
-          await toast.promise(createAppMetadata(payload), {
+          await toast.promise(upsertAppMetadata(payload), {
             error: "There was an error updating the app metadata.",
             loading: "Creating the app metadata.",
             success: "Created the app metadata!",

--- a/projects/ui/src/Utility/AdminUtility/CustomMetadataEditor.tsx
+++ b/projects/ui/src/Utility/AdminUtility/CustomMetadataEditor.tsx
@@ -2,8 +2,8 @@ import { Box, Flex, Input, Text } from "@mantine/core";
 import { FormEvent, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import {
-  CreateUpdateAppMetadataParams,
-  CreateUpdateSubscriptionMetadataParams,
+  UpsertAppMetadataParams,
+  UpsertSubscriptionMetadataParams,
   useUpsertAppMetadataMutation,
   useUpsertSubscriptionMetadataMutation,
 } from "../../Apis/gg_hooks";
@@ -58,7 +58,7 @@ export const CustomMetadataEditor = ({
     (async () => {
       if ("applicationId" in item) {
         // This is a Subscription
-        const payload: CreateUpdateSubscriptionMetadataParams["arg"] = {
+        const payload: UpsertSubscriptionMetadataParams["arg"] = {
           customMetadata: editedCustomMetadata,
           rateLimit: rateLimitInfo,
           subscription: item,
@@ -81,7 +81,7 @@ export const CustomMetadataEditor = ({
         }
       } else {
         // This is an App
-        const payload: CreateUpdateAppMetadataParams["arg"] = {
+        const payload: UpsertAppMetadataParams["arg"] = {
           customMetadata: editedCustomMetadata,
           rateLimit: rateLimitInfo,
           appId: item.id,

--- a/projects/ui/src/Utility/AdminUtility/RateLimitEditor.tsx
+++ b/projects/ui/src/Utility/AdminUtility/RateLimitEditor.tsx
@@ -1,9 +1,10 @@
-import {Box, Flex, NumberInput, Select, Text} from "@mantine/core";
+import { Box, Flex, NumberInput, Select, Text } from "@mantine/core";
 import { FormEvent, useRef, useState } from "react";
 import toast from "react-hot-toast";
+import { RateLimitUnit, rateLimitUnitOptions } from "../../Apis/api-types";
 import {
-  CreateUpdateAppMetadataParams,
-  CreateUpdateSubscriptionMetadataParams,
+  UpsertAppMetadataParams,
+  UpsertSubscriptionMetadataParams,
   useUpsertAppMetadataMutation,
   useUpsertSubscriptionMetadataMutation,
 } from "../../Apis/gg_hooks";
@@ -11,7 +12,6 @@ import { Button } from "../../Components/Common/Button";
 import { useIsAdmin } from "../../Context/AuthContext";
 import { shallowEquals } from "../utility";
 import { SharedMetadataProps } from "./MetadataDisplay";
-import {RateLimitUnit, rateLimitUnits} from "../../Apis/api-types";
 
 export const RateLimitEditor = ({
   item,
@@ -61,7 +61,7 @@ export const RateLimitEditor = ({
     (async () => {
       if ("applicationId" in item) {
         // This is a Subscription
-        const payload: CreateUpdateSubscriptionMetadataParams["arg"] = {
+        const payload: UpsertSubscriptionMetadataParams["arg"] = {
           customMetadata: newCustomMetadata,
           rateLimit: newRateLimitInfo,
           subscription: item,
@@ -84,7 +84,7 @@ export const RateLimitEditor = ({
         }
       } else {
         // This is an App
-        const payload: CreateUpdateAppMetadataParams["arg"] = {
+        const payload: UpsertAppMetadataParams["arg"] = {
           customMetadata: newCustomMetadata,
           rateLimit: newRateLimitInfo,
           appId: item.id,
@@ -188,22 +188,18 @@ export const RateLimitEditor = ({
                 <label htmlFor="unit-input">Unit</label>
               </Text>
               <Select
-                  // size="xs"
-                  required
-                  disabled={!isEditingRateLimit}
-                  id="unit-input"
-                  data={
-                    rateLimitUnits.map((unit) => ({
-                        value: unit,
-                        label: unit,
-                    }))
+                required
+                disabled={!isEditingRateLimit}
+                id="unit-input"
+                data={rateLimitUnitOptions}
+                onChange={(value: RateLimitUnit | null) => {
+                  if (!!value) {
+                    setUnit(value);
                   }
-                  onChange={(value: RateLimitUnit | null) => {
-                    value && setUnit(value)
-                  }}
-                  value={unit}
-                  placeholder="Unit"
-                  autoComplete="off"
+                }}
+                value={unit}
+                placeholder="Unit"
+                autoComplete="off"
               />
             </Flex>
           </Flex>


### PR DESCRIPTION
Thanks to Nick, validated on gg portal `main` branch build following the instructions to kill `4000` and run the `make ui` command.

- updated endpoint for metadata updates. in the backend we use a single endpoint for upserts.
- updated admin subscription modal to not disable the toggling of subscription status.
- updated unit to be specific fields (""HOUR" "DAY" , etc.)

need to verify creating new subscription doesn't break ui when no rate limit is set (that UNKNOWN works as expected)

https://github.com/user-attachments/assets/796e6fa6-5b6f-41a9-80a4-be78a2b2b962


BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/7038