### PR TITLE
Apis Page Reload Fix

### DIFF
--- a/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
+++ b/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
@@ -2,4 +2,4 @@ changelog:
   - type: NEW_FEATURE
     description: >-
       Fixes the API page reload behavior when navigating to it with `VITE_API_PAGE_RELOAD=true`,
-      so that the React Router behavior is overriden in that case.
+      so that the React Router behavior is overridden in that case.

--- a/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
+++ b/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
@@ -3,4 +3,3 @@ changelog:
     description: >-
       Fixes the API page reload behavior when navigating to it with `VITE_API_PAGE_RELOAD=true`,
       so that the React Router behavior is overridden in that case.
-    skipCI: true

--- a/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
+++ b/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >-
+      Fixes the API page reload behavior when navigating to it with `VITE_API_PAGE_RELOAD=true`,
+      so that the React Router behavior is overriden in that case.

--- a/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
+++ b/changelog/v0.0.37/api-page-reload-env-var-fix.yaml
@@ -3,3 +3,4 @@ changelog:
     description: >-
       Fixes the API page reload behavior when navigating to it with `VITE_API_PAGE_RELOAD=true`,
       so that the React Router behavior is overridden in that case.
+    skipCI: true

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { MouseEventHandler, useContext, useMemo } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import { ReactComponent as Logo } from "../../Assets/logo.svg";
 import { AppContext } from "../../Context/AppContext";
@@ -16,6 +16,17 @@ if (!window.isSecureContext) {
       "so login will not work."
   );
 }
+
+// If apiPageReload is true use the onclick to reload the page
+export const onApisPageClick: MouseEventHandler<HTMLAnchorElement> | undefined =
+  apiPageReload === "true"
+    ? (e) => {
+        // If we are using `apiPageReload=true`, we want to override the react router
+        // behavior here, otherwise we get 2 `/apis` page history entries.
+        e.preventDefault();
+        window.location.href = "/apis";
+      }
+    : undefined;
 
 /**
  * MAIN COMPONENT
@@ -89,17 +100,7 @@ export function Header() {
           */}
           <NavLink
             to={"/apis"}
-            // if apiPageReload is true use the onclick to reload the page
-            onClick={
-              apiPageReload === "true"
-                ? (e) => {
-                    // If we are using `apiPageReload=true`, we want to override the react router
-                    // behavior here, otherwise we get 2 `/apis` page history entries.
-                    e.preventDefault();
-                    window.location.href = "/apis";
-                  }
-                : undefined
-            }
+            onClick={onApisPageClick}
             className={`navLink ${inAPIsArea ? "active" : ""}`}
           >
             APIs

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -3,7 +3,7 @@ import { Link, NavLink, useLocation } from "react-router-dom";
 import { ReactComponent as Logo } from "../../Assets/logo.svg";
 import { AppContext } from "../../Context/AppContext";
 import { AuthContext } from "../../Context/AuthContext";
-import {apiPageReload, logoImageURL} from "../../user_variables.tmplr";
+import { apiPageReload, logoImageURL } from "../../user_variables.tmplr";
 import { ErrorBoundary } from "../Common/ErrorBoundary";
 import { HeaderStyles } from "./Header.style";
 import HeaderSectionLoggedIn from "./HeaderSectionLoggedIn";
@@ -90,7 +90,16 @@ export function Header() {
           <NavLink
             to={"/apis"}
             // if apiPageReload is true use the onclick to reload the page
-            onClick={apiPageReload === "true" ? () => (window.location.href = "/apis") : undefined}
+            onClick={
+              apiPageReload === "true"
+                ? (e) => {
+                    // If we are using `apiPageReload=true`, we want to override the react router
+                    // behavior here, otherwise we get 2 `/apis` page history entries.
+                    e.preventDefault();
+                    window.location.href = "/apis";
+                  }
+                : undefined
+            }
             className={`navLink ${inAPIsArea ? "active" : ""}`}
           >
             APIs

--- a/projects/ui/src/Components/Structure/OidcAuthCodeHeaderVariant/OidcAuthCodeHeaderVariant.tsx
+++ b/projects/ui/src/Components/Structure/OidcAuthCodeHeaderVariant/OidcAuthCodeHeaderVariant.tsx
@@ -2,10 +2,10 @@ import { useContext, useMemo } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import { ReactComponent as Logo } from "../../../Assets/logo.svg";
 import { AppContext } from "../../../Context/AppContext";
+import { apiPageReload } from "../../../user_variables.tmplr";
 import { ErrorBoundary } from "../../Common/ErrorBoundary";
 import { HeaderStyles } from "../Header.style";
 import { OidcAuthCodeHeaderDropdown } from "./OidcAuthCodeHeaderDropdown";
-import {apiPageReload} from "../../../user_variables.tmplr";
 
 /**
  * This is for when there is an
@@ -37,7 +37,16 @@ const OidcAuthCodeHeaderVariant = () => {
           </NavLink>
           <NavLink
             to={"/apis"}
-            onClick={apiPageReload === "true" ? () => (window.location.href = "/apis") : undefined}
+            onClick={
+              apiPageReload === "true"
+                ? (e) => {
+                    // If we are using `apiPageReload=true`, we want to override the react router
+                    // behavior here, otherwise we get 2 `/apis` page history entries.
+                    e.preventDefault();
+                    window.location.href = "/apis";
+                  }
+                : undefined
+            }
             className={`navLink ${inAPIsArea ? "active" : ""}`}
           >
             APIs

--- a/projects/ui/src/Components/Structure/OidcAuthCodeHeaderVariant/OidcAuthCodeHeaderVariant.tsx
+++ b/projects/ui/src/Components/Structure/OidcAuthCodeHeaderVariant/OidcAuthCodeHeaderVariant.tsx
@@ -2,8 +2,8 @@ import { useContext, useMemo } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
 import { ReactComponent as Logo } from "../../../Assets/logo.svg";
 import { AppContext } from "../../../Context/AppContext";
-import { apiPageReload } from "../../../user_variables.tmplr";
 import { ErrorBoundary } from "../../Common/ErrorBoundary";
+import { onApisPageClick } from "../Header";
 import { HeaderStyles } from "../Header.style";
 import { OidcAuthCodeHeaderDropdown } from "./OidcAuthCodeHeaderDropdown";
 
@@ -37,16 +37,7 @@ const OidcAuthCodeHeaderVariant = () => {
           </NavLink>
           <NavLink
             to={"/apis"}
-            onClick={
-              apiPageReload === "true"
-                ? (e) => {
-                    // If we are using `apiPageReload=true`, we want to override the react router
-                    // behavior here, otherwise we get 2 `/apis` page history entries.
-                    e.preventDefault();
-                    window.location.href = "/apis";
-                  }
-                : undefined
-            }
+            onClick={onApisPageClick}
             className={`navLink ${inAPIsArea ? "active" : ""}`}
           >
             APIs


### PR DESCRIPTION
Fixes the API page reload behavior when navigating to it with `VITE_API_PAGE_RELOAD=true`, so that the React Router behavior is overridden in that case.