### PR TITLE
build: add opt-in distroless serve-stage Dockerfile

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,47 @@
+###############
+#             #
+# Build Stage #
+#             #
+###############
+#
+# Identical to the default Dockerfile's build stage. Keep the two in sync.
+
+FROM node:22.22.2 AS build_stage
+
+# Install global dependencies.
+RUN apt-get update && apt-get install -y build-essential
+
+# Copy all project files.
+WORKDIR /app
+COPY ./projects projects
+COPY ./scripts scripts
+
+# Run the startup script, without starting the server (installs deps, builds
+# the UI, moves the build into the server project, injects the EJS env view).
+RUN START_SERVER=false sh ./scripts/startup.sh
+
+###############
+#             #
+# Serve Stage #
+#             #
+###############
+#
+# Opt-in minimal serve base. Google distroless Node 22 has no shell and no
+# package manager, which shrinks the OS package surface to near-zero
+# HIGH/CRITICAL CVEs. Because there is no npm here, this variant also omits the
+# `npm install -g npm@latest` self-update step used by the default slim base
+# (the runtime deps are already pinned via projects/ui/package.json resolutions).
+
+FROM gcr.io/distroless/nodejs22-debian12:nonroot AS serve_stage
+
+# Copy the server files (this includes the built UI).
+WORKDIR /app
+COPY --from=build_stage /app/projects/server .
+
+EXPOSE 4000
+
+# The distroless image's entrypoint is already `node`, so we exec the server
+# directly. The server reads its VITE_* configuration from process.env at
+# runtime (injected by your deployment), so no shell-form env re-export is
+# needed here; behavior matches the default Dockerfile's shell-form ENTRYPOINT.
+CMD ["/app/bin/www"]

--- a/changelog/v0.1.9/distroless-serve-base.yaml
+++ b/changelog/v0.1.9/distroless-serve-base.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Adds an opt-in Dockerfile.distroless that builds the serve stage on a
+      minimal Google distroless Node base, for CVE-gated image pipelines. The
+      default Dockerfile is unchanged.


### PR DESCRIPTION
## What

Adds an opt-in `Dockerfile.distroless` that builds the portal frontend on a minimal (Google distroless) Node base for the serve stage. The default `Dockerfile` is unchanged. (A short README note on when to use it will follow as a separate docs change, to avoid conflicting with the in-flight README re-home in #160.)

## Why

The published demo image and the default slim build carry a large OS-package CVE surface, which blocks promotion in CVE-gated image pipelines (for example, a registry that rejects images with HIGH/CRITICAL findings). A distroless serve base drops that surface to near-zero without touching the application.

Measured with trivy (HIGH+CRITICAL; identical counts and CVE IDs on amd64 and arm64):

| Serve base | HIGH+CRIT |
|---|---|
| published demo `portal-frontend:v0.1.8` | ~1,729 |
| default `node:22.23.1-bookworm-slim` | 21 |
| `gcr.io/distroless/nodejs22-debian12:nonroot` | 6 (→ ~0 on a fresh base digest) |

For a zero-CVE option, `cgr.dev/chainguard/node` measures 0, but pinning a Chainguard tag requires a Chainguard subscription, so distroless is the better default for a public starter. A Chainguard variant is easy to add if you want it.

## Design: why a separate file, not a build-arg

The distroless serve stage differs structurally from the slim stage: it has no shell and no npm. So it omits the `npm install -g npm@latest` self-update step (unnecessary; the runtime deps are pinned via `projects/ui/package.json` resolutions) and uses an exec-form `CMD` instead of the default's shell-form `ENTRYPOINT`. A single Dockerfile with a swappable base cannot express both cleanly, so this is a separate opt-in file. Consumers who do not opt in see no change.

The server reads its `VITE_*` configuration from `process.env` at runtime (injected by the deployment), so the exec-form entrypoint is behaviorally equivalent to the default's shell-form env re-export.

## Validation

Built, run (HTTP 200, SPA served), and trivy-scanned on both amd64 and arm64. The built image is consumer-agnostic (same frontend, same `/v1` contract), and was wired to a real Portal backend and exercised end to end (including OIDC login via `oidcAuthorizationCode`) in-cluster on:

- Gloo Gateway 1.21.7 (v1 Portal)
- Solo Enterprise for kgateway 2.2.4 (v2 Portal), including with the portal workloads running inside an ambient mesh.

The change is purely additive: it adds a file and leaves the default `Dockerfile` untouched, so existing builds are unaffected regardless of consumer.

## Precedent

`gloo-gateway#2039` (merged) already moved the Portal backend to a Chainguard base image; this extends the same minimal-base direction to the frontend starter.
