### PR TITLE
docs: document the opt-in distroless Dockerfile in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ The portal is decoupled: the Solo-supported backend (`portal-web-server`, plus t
 
   - If you intend to run this app in the mesh behind an `oidcAuthorizationCode` config, you will need to update the image name and environment variables in your portal frontend deployment. See [Environment Variables if using an "oidcAuthorizationCode" AuthConfig](#environment-variables-if-using-an-oidcauthorizationcode-authconfig) below, and the [Secure login guide](https://docs.solo.io/kgateway/2.2.x/portal/frontend-setup/login/) for how the gateway wires it.
 
+### Building a minimal (distroless) image
+
+For environments with a CVE-gated image pipeline (a registry that rejects images with HIGH/CRITICAL findings), build from `Dockerfile.distroless` instead of the default `Dockerfile`:
+
+```shell
+docker build -f Dockerfile.distroless -t "your-image-name" .
+```
+
+This uses a Google distroless Node base for the serve stage. The image is functionally identical, with a much smaller OS package surface (near-zero HIGH/CRITICAL OS CVEs). The trade-off is that the running container has no shell. The default `Dockerfile` is unchanged.
+
+If you use Chainguard, a `cgr.dev/chainguard/node` serve base reaches zero OS CVEs; note that pinning a Chainguard tag requires a Chainguard subscription.
+
 ## UI Development
 
 **Prerequisites for Local Development**:

--- a/changelog/v0.1.9/distroless-readme-note.yaml
+++ b/changelog/v0.1.9/distroless-readme-note.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Documents the opt-in Dockerfile.distroless build in the README.


### PR DESCRIPTION
## What

Adds a short "Building a minimal (distroless) image" note to the README, documenting the opt-in `Dockerfile.distroless` added in #162.

## Sequencing — please merge this last

This is stacked on the README re-home branch (`docs/readme-sefk-rehome`, PR #161) because both touch `README.md`. Please merge it **after** #161 and #162:

- While #161 is open, this PR's diff also shows #161's changes. Once #161 merges into `main`, this PR collapses to just the doc note.
- If #161 changes during review, this branch will be rebased on top of it.

Docs-only; no code or build change.
