### PR TITLE
build: default to distroless serve base; run e2e against the built image

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,10 +26,8 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Install UI dependencies
-        working-directory: projects/ui
-        run: yarn install --immutable
-
+      # The UI is built inside the Docker image (see e2e/setup.ts), so the UI
+      # deps do not need to be installed on the host runner.
       - name: Install mock API dependencies
         working-directory: mock-portal-api
         run: yarn install --immutable

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,59 +30,22 @@ RUN START_SERVER=false sh ./scripts/startup.sh
 #             #
 ###############
 
-FROM node:22.23.1-bookworm-slim AS serve_stage
+# Minimal serve base. Google distroless Node 22 has no shell and no package
+# manager, which shrinks the OS package surface to near-zero HIGH/CRITICAL CVEs
+# and lets CVE-gated pipelines promote the image. Because there is no npm here,
+# this stage also drops the `npm install -g npm@latest` self-update step the
+# slim base used (its runtime deps are already pinned via the build stage).
+FROM gcr.io/distroless/nodejs22-debian12:nonroot AS serve_stage
 
-# Update npm to pull in patched bundled deps (picomatch, brace-expansion, ip-address CVEs).
-RUN npm install -g npm@latest && npm cache clean --force
-
-ENV VITE_PORTAL_SERVER_URL=$VITE_PORTAL_SERVER_URL \
-    VITE_CLIENT_ID=$VITE_CLIENT_ID \
-    VITE_TOKEN_ENDPOINT=$VITE_TOKEN_ENDPOINT \
-    VITE_AUTH_ENDPOINT=$VITE_AUTH_ENDPOINT \
-    VITE_LOGOUT_ENDPOINT=$VITE_LOGOUT_ENDPOINT \
-    VITE_APPLIED_OIDC_AUTH_CODE_CONFIG=$VITE_APPLIED_OIDC_AUTH_CODE_CONFIG \
-    VITE_OIDC_AUTH_CODE_CONFIG_CALLBACK_PATH=$VITE_OIDC_AUTH_CODE_CONFIG_CALLBACK_PATH \
-    VITE_OIDC_AUTH_CODE_CONFIG_LOGOUT_PATH=$VITE_OIDC_AUTH_CODE_CONFIG_LOGOUT_PATH \
-    VITE_SWAGGER_CONFIG_URL=$VITE_SWAGGER_CONFIG_URL \
-    VITE_AUDIENCE=$VITE_AUDIENCE \
-    VITE_HOME_IMAGE_URL=$VITE_HOME_IMAGE_URL \
-    VITE_BANNER_IMAGE_URL=$VITE_BANNER_IMAGE_URL \
-    VITE_LOGO_IMAGE_URL=$VITE_LOGO_IMAGE_URL \
-    VITE_COMPANY_NAME=$VITE_COMPANY_NAME \
-    VITE_CUSTOM_PAGES=$VITE_CUSTOM_PAGES \
-    VITE_SWAGGER_PREFILL_API_KEY=$VITE_SWAGGER_PREFILL_API_KEY \
-    VITE_SWAGGER_PREFILL_OAUTH=$VITE_SWAGGER_PREFILL_OAUTH \
-    VITE_SWAGGER_PREFILL_BASIC=$VITE_SWAGGER_PREFILL_BASIC \
-    VITE_DEFAULT_APP_AUTH=$VITE_DEFAULT_APP_AUTH \
-    VITE_API_PAGE_RELOAD=$VITE_API_PAGE_RELOAD
-
-# Copy the server files, (this includes the UI build).
+# Copy the server files (this includes the built UI).
 WORKDIR /app
 COPY --from=build_stage /app/projects/server .
 
-# Pass through the environment variables, and then start the server.
-# These variables will change when the image is deployed.
-# This needs to be `node ./bin/www` instead of `yarn start because
-# running yarn causes a yarn cache file to change, which doesn't work
-# in read-only environments.
-ENTRYPOINT VITE_PORTAL_SERVER_URL=$VITE_PORTAL_SERVER_URL \
-    VITE_CLIENT_ID=$VITE_CLIENT_ID \
-    VITE_TOKEN_ENDPOINT=$VITE_TOKEN_ENDPOINT \
-    VITE_AUTH_ENDPOINT=$VITE_AUTH_ENDPOINT \
-    VITE_LOGOUT_ENDPOINT=$VITE_LOGOUT_ENDPOINT \
-    VITE_APPLIED_OIDC_AUTH_CODE_CONFIG=$VITE_APPLIED_OIDC_AUTH_CODE_CONFIG \
-    VITE_OIDC_AUTH_CODE_CONFIG_CALLBACK_PATH=$VITE_OIDC_AUTH_CODE_CONFIG_CALLBACK_PATH \
-    VITE_OIDC_AUTH_CODE_CONFIG_LOGOUT_PATH=$VITE_OIDC_AUTH_CODE_CONFIG_LOGOUT_PATH \
-    VITE_SWAGGER_CONFIG_URL=$VITE_SWAGGER_CONFIG_URL \
-    VITE_AUDIENCE=$VITE_AUDIENCE \
-    VITE_HOME_IMAGE_URL=$VITE_HOME_IMAGE_URL \
-    VITE_BANNER_IMAGE_URL=$VITE_BANNER_IMAGE_URL \
-    VITE_LOGO_IMAGE_URL=$VITE_LOGO_IMAGE_URL \
-    VITE_COMPANY_NAME=$VITE_COMPANY_NAME \
-    VITE_CUSTOM_PAGES=$VITE_CUSTOM_PAGES \
-    VITE_SWAGGER_PREFILL_API_KEY=$VITE_SWAGGER_PREFILL_API_KEY \
-    VITE_SWAGGER_PREFILL_OAUTH=$VITE_SWAGGER_PREFILL_OAUTH \
-    VITE_SWAGGER_PREFILL_BASIC=$VITE_SWAGGER_PREFILL_BASIC \
-    VITE_DEFAULT_APP_AUTH=$VITE_DEFAULT_APP_AUTH \
-    VITE_API_PAGE_RELOAD=$VITE_API_PAGE_RELOAD \
-    node ./bin/www
+EXPOSE 4000
+
+# The distroless image's entrypoint is already `node`, so we exec the server
+# directly. The server reads its VITE_* configuration from process.env at
+# runtime (injected by your deployment), so no shell-form env re-export is
+# needed. We run `node ./bin/www` rather than `yarn start` because running yarn
+# mutates a cache file, which fails in read-only environments.
+CMD ["/app/bin/www"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ This is an example Solo.io Gloo Platform Dev Portal frontend app, built with [Vi
 
   - If running this app in the mesh with an `ExtAuthPolicy` that has an "oidcAuthorizationCode" config, you will need to update the image name and environment variables in your portal frontend deployment. See the [Environment Variables if using an oidcAuthorizationCode ExtAuthPolicy](#environment-variables-if-using-an-oidcauthorizationcode-extauthpolicy) of this Readme for more details.
 
+### About the container image
+
+The `Dockerfile` builds the serve stage on a [Google distroless](https://github.com/GoogleContainerTools/distroless) Node base. This keeps the OS package surface small (near-zero HIGH/CRITICAL OS CVEs), which matters for CVE-gated image pipelines — registries that reject images with HIGH/CRITICAL findings. The image is functionally identical to a slim-based build; the trade-off is that the running container has no shell, so you cannot `docker exec` into it with a shell to debug.
+
+If you need an even smaller CVE surface, a Chainguard `cgr.dev/chainguard/node` serve base reaches zero OS CVEs; note that pinning a Chainguard tag requires a Chainguard subscription.
+
 ## UI Development
 
 **Prerequisites for Local Development**:

--- a/changelog/v0.1.9/distroless-serve-base.yaml
+++ b/changelog/v0.1.9/distroless-serve-base.yaml
@@ -1,0 +1,17 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Switches the default Dockerfile serve stage to a minimal Google distroless
+      Node base. This shrinks the OS package CVE surface to near-zero
+      HIGH/CRITICAL and removes npm from the runtime image.
+  - type: NON_USER_FACING
+    description: >
+      Documents in the README that the default image serve stage is built on a
+      distroless Node base, including the no-shell trade-off and a Chainguard
+      option for a zero-CVE base.
+  - type: NON_USER_FACING
+    description: >
+      The e2e test now builds and runs the production Docker image and drives it
+      (catalog, then the Redoc and Swagger OpenAPI views) instead of the Vite dev
+      server. Also adds the required openapi field to the mock specs so the
+      OpenAPI renderers load.

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,9 +1,12 @@
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, ChildProcess, execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import * as path from 'path';
 
 const ROOT = path.resolve(__dirname, '..');
 const PID_FILE = path.join(__dirname, '.e2e-pids.json');
+const IMAGE = process.env.E2E_IMAGE || 'devportal-e2e:latest';
+const CONTAINER = 'devportal-e2e';
+const UI_PORT = process.env.E2E_UI_PORT || '4173';
 
 function waitForUrl(
   url: string,
@@ -56,7 +59,15 @@ function spawnProcess(
 export default async function globalSetup() {
   console.log('\n=== E2E Setup: Starting infrastructure ===\n');
 
-  // 1. Start Mock Portal API
+  // 1. Build the production image from the repo Dockerfile. Running the tests
+  //    against the built image (rather than the Vite dev server) means the e2e
+  //    suite also exercises what we actually ship: the multi-stage build, the
+  //    served static bundle, and runtime VITE_* env injection.
+  console.log(`Building image ${IMAGE} from ./Dockerfile ...`);
+  execSync(`docker build -t ${IMAGE} .`, { cwd: ROOT, stdio: 'inherit' });
+  console.log('Image built.');
+
+  // 2. Start Mock Portal API on the host (the browser calls it directly).
   console.log('Starting Mock Portal API...');
   const mockApi = spawnProcess(
     'node',
@@ -64,31 +75,31 @@ export default async function globalSetup() {
     path.join(ROOT, 'mock-portal-api'),
   );
 
-  // 2. Wait for mock API to be ready
+  // 3. Wait for mock API to be ready
   await waitForUrl('http://localhost:31080/health', 15_000);
   console.log('Mock Portal API ready.');
 
-  // 3. Start the Vite UI dev server on a dedicated e2e port
-  const uiPort = process.env.E2E_UI_PORT || '4173';
-  console.log(`Starting UI dev server on port ${uiPort}...`);
-  const ui = spawnProcess(
-    'yarn',
-    ['vite', '--port', uiPort, '--strictPort'],
-    path.join(ROOT, 'projects', 'ui'),
-    { VITE_PORTAL_SERVER_URL: 'http://localhost:31080/v1' },
+  // 4. Run the built image. The server reads VITE_* config from process.env at
+  //    runtime and injects it into the served HTML; the browser then uses it.
+  execSync(`docker rm -f ${CONTAINER} 2>/dev/null || true`, { stdio: 'ignore' });
+  console.log(`Starting container on port ${UI_PORT}...`);
+  execSync(
+    `docker run -d --name ${CONTAINER} -p ${UI_PORT}:4000 ` +
+      `-e VITE_PORTAL_SERVER_URL=http://localhost:31080/v1 ${IMAGE}`,
+    { stdio: 'inherit' },
   );
 
-  // 4. Wait for UI to be ready
-  console.log(`Waiting for UI dev server (port ${uiPort})...`);
-  await waitForUrl(`http://localhost:${uiPort}`, 120_000, true);
-  console.log('UI dev server ready.');
+  // 5. Wait for the containerized server to serve.
+  console.log(`Waiting for server (port ${UI_PORT})...`);
+  await waitForUrl(`http://localhost:${UI_PORT}`, 60_000, true);
+  console.log('Server ready.');
 
-  // Save PIDs for teardown
+  // Save handles for teardown
   writeFileSync(
     PID_FILE,
     JSON.stringify({
       mockApi: mockApi.pid,
-      ui: ui.pid,
+      container: CONTAINER,
     }),
   );
 

--- a/e2e/teardown.ts
+++ b/e2e/teardown.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { readFileSync, unlinkSync, existsSync } from 'fs';
 import * as path from 'path';
 
@@ -15,21 +16,22 @@ function killProcessTree(pid: number) {
 export default async function globalTeardown() {
   console.log('\n=== E2E Teardown: Stopping services ===\n');
 
-  // Kill spawned processes
   if (existsSync(PID_FILE)) {
     try {
-      const pids = JSON.parse(readFileSync(PID_FILE, 'utf-8'));
-      if (pids.mockApi) {
-        console.log(`Stopping Mock API (PID ${pids.mockApi})...`);
-        killProcessTree(pids.mockApi);
+      const state = JSON.parse(readFileSync(PID_FILE, 'utf-8'));
+      if (state.container) {
+        console.log(`Removing container ${state.container}...`);
+        execSync(`docker rm -f ${state.container} 2>/dev/null || true`, {
+          stdio: 'ignore',
+        });
       }
-      if (pids.ui) {
-        console.log(`Stopping UI dev server (PID ${pids.ui})...`);
-        killProcessTree(pids.ui);
+      if (state.mockApi) {
+        console.log(`Stopping Mock API (PID ${state.mockApi})...`);
+        killProcessTree(state.mockApi);
       }
       unlinkSync(PID_FILE);
     } catch (e) {
-      console.warn('Warning cleaning up PIDs:', e);
+      console.warn('Warning cleaning up:', e);
     }
   }
 

--- a/e2e/tests/catalog.spec.ts
+++ b/e2e/tests/catalog.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-test('APIs page shows all APIs from the mock portal', async ({ page }) => {
-  // Navigate to the APIs page
+test('APIs page, then API detail Redoc + Swagger views, against the built image', async ({
+  page,
+}) => {
+  // 1. Navigate to the APIs page.
   await page.goto('/apis');
 
   // Wait for the API list to load — the mock portal serves 3 API products.
@@ -14,6 +16,26 @@ test('APIs page shows all APIs from the mock portal', async ({ page }) => {
   await expect(petstoreApi).toBeVisible({ timeout: 10_000 });
   await expect(ordersApi).toBeVisible({ timeout: 10_000 });
 
-  // Capture a screenshot of the loaded APIs page
   await page.screenshot({ path: 'test-results/apis-page.png', fullPage: true });
+
+  // 2. Open the Tracks API detail page (card is a link to the Spec tab).
+  await tracksApi.click();
+
+  // 3. The Spec tab renders with Redoc by default. Redoc is a heavy bundle and
+  //    renders its spec asynchronously, so wait for real spec content (the API
+  //    title from the mock's OpenAPI doc) before capturing.
+  await expect(
+    page.getByRole('heading', { name: /Tracks REST API/i }),
+  ).toBeVisible({ timeout: 60_000 });
+  await page.screenshot({ path: 'test-results/redoc-view.png', fullPage: true });
+
+  // 4. Toggle to the Swagger view and confirm the swagger-ui library renders.
+  await page.getByRole('button', { name: /Swagger View/i }).click();
+  const swaggerUi = page.locator('.swagger-ui');
+  await expect(swaggerUi).toBeVisible({ timeout: 30_000 });
+  // The operation summary from the mock spec confirms swagger-ui parsed it.
+  await expect(page.getByText('List all tracks').first()).toBeVisible({
+    timeout: 30_000,
+  });
+  await page.screenshot({ path: 'test-results/swagger-view.png', fullPage: true });
 });

--- a/mock-portal-api/data.js
+++ b/mock-portal-api/data.js
@@ -3,6 +3,7 @@
 // -------------------------------------------------------
 
 const openApiSpec = {
+  openapi: "3.0.0",
   info: { title: "Tracks REST API", version: "1.0.0" },
   servers: [{ url: "http://localhost:8080" }],
   paths: {
@@ -52,6 +53,7 @@ const openApiSpec = {
 };
 
 const ordersSpec = {
+  openapi: "3.0.0",
   info: { title: "Orders API", version: "1.0.0" },
   servers: [{ url: "http://localhost:31080" }],
   paths: {
@@ -99,6 +101,7 @@ const ordersSpec = {
 };
 
 const petStoreSpec = {
+  openapi: "3.0.0",
   info: { title: "Petstore API", version: "2.0.0" },
   servers: [{ url: "http://localhost:31080" }],
   paths: {


### PR DESCRIPTION
## Description

<!-- Added manually — do not overwrite. -->

---
*🤖 written by Claude (start)*

## Changelog

The default `Dockerfile` serve stage now builds on a Google distroless Node base (near-zero HIGH/CRITICAL OS CVEs, no shell, no npm). The e2e test now builds and runs that production image and drives the Redoc and Swagger OpenAPI views, replacing the Vite dev server.

## Changes

- `Dockerfile`: distroless serve stage by default. The old shell-form env re-export was a no-op (the server reads `VITE_*` straight from `process.env`) and npm is no longer present, so both were dropped.
- `e2e/`: the single test builds + runs the image, then drives catalog → API detail → Redoc → Swagger, capturing screenshots and video.
- `mock-portal-api`: added the required `openapi` field to the mock specs so the OpenAPI renderers actually load.
- `README.md`: documents the distroless default (no-shell trade-off, Chainguard zero-CVE option).
- `.github/workflows/e2e.yaml`: dropped the now-redundant host UI-deps install (the image build handles it).

## Testing

Requires Docker running locally.

```sh
cd e2e && corepack yarn test
```

Builds the image, starts the mock API, runs the container, and drives catalog → API detail → Redoc view → Swagger view. Screenshots and `video.webm` land in `e2e/test-results/`.

---
*🤖 written by Claude (end)*