### PR TITLE
Give portal admins the API catalog and the self-service flows

### DIFF
--- a/changelog/v0.1.12/admin-api-catalog-and-self-service.yaml
+++ b/changelog/v0.1.12/admin-api-catalog-and-self-service.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo-gateway/issues/2601
+    resolvesIssue: false
+    description: >-
+      Portal admin users can now reach the API Product catalog and the
+      self-service flows that were previously hidden from them. The admin
+      navigation gains an APIs entry, giving admins the catalog, API Product
+      details, the OpenAPI spec views and try-it-out. Admins can also open an
+      app's details page from the Apps page, a team's app list and a
+      subscription card, and can create teams, create apps and add API keys.
+      The portal server already permitted all of these actions for admins;
+      only the UI withheld them.

--- a/changelog/v0.1.12/admin-api-catalog-and-self-service.yaml
+++ b/changelog/v0.1.12/admin-api-catalog-and-self-service.yaml
@@ -10,4 +10,6 @@ changelog:
       app's details page from the Apps page, a team's app list and a
       subscription card, and can create teams, create apps and add API keys.
       The portal server already permitted all of these actions for admins;
-      only the UI withheld them.
+      only the UI withheld them. The admin view now also identifies itself:
+      an Admin badge in the header, and Teams and Apps state whether the
+      list covers the whole portal or only the teams you belong to.

--- a/projects/ui/src/Components/Apps/AppsPage.test.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppsPage } from "./AppsPage";
+
+// The page lists apps per team, and the create-app modal reads the team list
+// and the create mutation on render. Neither is what these tests are about.
+vi.mock("../../Apis/gg_hooks", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useListTeams: () => ({ isLoading: false, data: [] }),
+  useListAppsForTeams: () => ({ isLoading: false, data: [] }),
+  useListFlatAppsForTeamsOmitErrors: () => ({ isLoading: false, data: [] }),
+  useCreateAppMutation: () => ({ trigger: vi.fn() }),
+}));
+
+const auth = vi.hoisted(() => ({ isAdmin: true }));
+vi.mock("../../Context/AuthContext", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useIsAdmin: () => auth.isAdmin,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+// AppsPage is also served as /admin/apps (AdminAppsPage re-exports it), so
+// this covers the admin apps page as well as the self-service one.
+describe("AppsPage", () => {
+  it("offers app creation to admins", () => {
+    auth.isAdmin = true;
+    render(
+      <MemoryRouter>
+        <AppsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("CREATE NEW APP")).not.toBeNull();
+  });
+
+  it("offers app creation to non-admins", () => {
+    auth.isAdmin = false;
+    render(
+      <MemoryRouter>
+        <AppsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("CREATE NEW APP")).not.toBeNull();
+  });
+});

--- a/projects/ui/src/Components/Apps/AppsPage.test.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.test.tsx
@@ -48,4 +48,34 @@ describe("AppsPage", () => {
 
     expect(screen.queryByText("CREATE NEW APP")).not.toBeNull();
   });
+
+  // The list is scoped to the caller on /apps and covers the whole
+  // portal on /admin/apps, so the wording has to distinguish them.
+  it("says the list covers the whole portal on the admin route", () => {
+    render(
+      <MemoryRouter initialEntries={["/admin/apps"]}>
+        <AppsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse all Apps in this portal."),
+    ).not.toBeNull();
+    expect(
+      screen.queryByText("Browse the Apps of the teams you belong to."),
+    ).toBeNull();
+  });
+
+  it("says the list is the caller's own on the self-service route", () => {
+    render(
+      <MemoryRouter initialEntries={["/apps"]}>
+        <AppsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse the Apps of the teams you belong to."),
+    ).not.toBeNull();
+    expect(screen.queryByText("Browse all Apps in this portal.")).toBeNull();
+  });
 });

--- a/projects/ui/src/Components/Apps/AppsPage.test.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.test.tsx
@@ -49,11 +49,24 @@ describe("AppsPage", () => {
     expect(screen.queryByText("CREATE NEW APP")).not.toBeNull();
   });
 
-  // The list is scoped to the caller on /apps and covers the whole
-  // portal on /admin/apps, so the wording has to distinguish them.
-  it("says the list covers the whole portal on the admin route", () => {
+  // Scope follows the caller's mode rather than the URL (see TeamsPage).
+  it("says the list covers the whole portal for admins", () => {
+    auth.isAdmin = true;
     render(
       <MemoryRouter initialEntries={["/admin/apps"]}>
+        <AppsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse all Apps in this portal."),
+    ).not.toBeNull();
+  });
+
+  it("says the list covers the whole portal for admins on /apps too", () => {
+    auth.isAdmin = true;
+    render(
+      <MemoryRouter initialEntries={["/apps"]}>
         <AppsPage />
       </MemoryRouter>,
     );
@@ -66,7 +79,8 @@ describe("AppsPage", () => {
     ).toBeNull();
   });
 
-  it("says the list is the caller's own on the self-service route", () => {
+  it("says the list is membership-scoped for non-admins", () => {
+    auth.isAdmin = false;
     render(
       <MemoryRouter initialEntries={["/apps"]}>
         <AppsPage />
@@ -77,5 +91,19 @@ describe("AppsPage", () => {
       screen.queryByText("Browse the Apps of the teams you belong to."),
     ).not.toBeNull();
     expect(screen.queryByText("Browse all Apps in this portal.")).toBeNull();
+  });
+
+  // The route alone must not move the copy.
+  it("keeps the membership-scoped copy for a non-admin on the admin route", () => {
+    auth.isAdmin = false;
+    render(
+      <MemoryRouter initialEntries={["/admin/apps"]}>
+        <AppsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse the Apps of the teams you belong to."),
+    ).not.toBeNull();
   });
 });

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -1,7 +1,6 @@
 import { Box } from "@mantine/core";
 import { useState } from "react";
 import { Icon } from "../../Assets/Icons";
-import { useIsAdmin } from "../../Context/AuthContext";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
@@ -11,7 +10,6 @@ import { AppsPageContent } from "./PageContent/AppsPageContent";
 
 export function AppsPage() {
   const [modalOpen, setModalOpen] = useState(false);
-  const isAdmin = useIsAdmin();
 
   return (
     <PageContainer>
@@ -20,13 +18,9 @@ export function AppsPage() {
         description={
           <>
             Browse the list of Apps in this portal.
-            {!isAdmin && (
-              <Box pt={"20px"}>
-                <Button onClick={() => setModalOpen(true)}>
-                  CREATE NEW APP
-                </Button>
-              </Box>
-            )}
+            <Box pt={"20px"}>
+              <Button onClick={() => setModalOpen(true)}>CREATE NEW APP</Button>
+            </Box>
           </>
         }
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Apps" }]}

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -4,16 +4,16 @@ import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
+import { useIsAdmin } from "../../Context/AuthContext";
 import { PageContainer } from "../Common/PageContainer";
-import { useInArea } from "../../Utility/utility";
 import CreateNewAppModal from "./Modals/CreateNewAppModal";
 import { AppsPageContent } from "./PageContent/AppsPageContent";
 
 export function AppsPage() {
   const [modalOpen, setModalOpen] = useState(false);
-  // Served at both /apps and /admin/apps (AdminAppsPage re-exports it). See
-  // the note in TeamsPage: the wording follows the route, not the identity.
-  const inAdminArea = useInArea(["/admin/apps"]);
+  // See the note in TeamsPage: the app list is scoped to the caller's
+  // effective mode rather than to the URL, so the wording follows the mode.
+  const isAdmin = useIsAdmin();
 
   return (
     <PageContainer>
@@ -21,7 +21,7 @@ export function AppsPage() {
         title={<BannerHeadingTitle text={"Apps"} logo={<Icon.AppIcon />} />}
         description={
           <>
-            {inAdminArea
+            {isAdmin
               ? "Browse all Apps in this portal."
               : "Browse the Apps of the teams you belong to."}
             <Box pt={"20px"}>

--- a/projects/ui/src/Components/Apps/AppsPage.tsx
+++ b/projects/ui/src/Components/Apps/AppsPage.tsx
@@ -5,11 +5,15 @@ import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
 import { PageContainer } from "../Common/PageContainer";
+import { useInArea } from "../../Utility/utility";
 import CreateNewAppModal from "./Modals/CreateNewAppModal";
 import { AppsPageContent } from "./PageContent/AppsPageContent";
 
 export function AppsPage() {
   const [modalOpen, setModalOpen] = useState(false);
+  // Served at both /apps and /admin/apps (AdminAppsPage re-exports it). See
+  // the note in TeamsPage: the wording follows the route, not the identity.
+  const inAdminArea = useInArea(["/admin/apps"]);
 
   return (
     <PageContainer>
@@ -17,7 +21,9 @@ export function AppsPage() {
         title={<BannerHeadingTitle text={"Apps"} logo={<Icon.AppIcon />} />}
         description={
           <>
-            Browse the list of Apps in this portal.
+            {inAdminArea
+              ? "Browse all Apps in this portal."
+              : "Browse the Apps of the teams you belong to."}
             <Box pt={"20px"}>
               <Button onClick={() => setModalOpen(true)}>CREATE NEW APP</Button>
             </Box>

--- a/projects/ui/src/Components/Apps/Details/ApiKeysSection/AppApiKeysSection.tsx
+++ b/projects/ui/src/Components/Apps/Details/ApiKeysSection/AppApiKeysSection.tsx
@@ -3,7 +3,6 @@ import { useMemo, useState } from "react";
 import { di } from "react-magnetic-di";
 import { APIKey, App } from "../../../../Apis/api-types";
 import { useListApiKeysForApp } from "../../../../Apis/gg_hooks";
-import { useIsAdmin } from "../../../../Context/AuthContext";
 import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { UtilityStyles } from "../../../../Styles/shared/Utility.style";
@@ -21,8 +20,7 @@ import ConfirmDeleteApiKeyModal from "../Modals/ConfirmDeleteApiKeyModal";
 import AddApiKeysSubSection from "./AddApiKeysSubSection";
 
 const AppApiKeysSection = ({ app }: { app: App }) => {
-  di(useIsAdmin, useListApiKeysForApp);
-  const isAdmin = useIsAdmin();
+  di(useListApiKeysForApp);
   const { data: apiKeys } = useListApiKeysForApp(app.id);
   const [showAddApiKeySubSection, setShowAddApiKeySubSection] = useState(false);
 
@@ -66,15 +64,13 @@ const AppApiKeysSection = ({ app }: { app: App }) => {
     <DetailsPageStyles.Section>
       <Flex justify={"space-between"}>
         <DetailsPageStyles.Title>API Keys</DetailsPageStyles.Title>
-        {!isAdmin && (
-          <ToggleAddButton
-            topicUpperCase="API KEY"
-            isAdding={showAddApiKeySubSection}
-            toggleAdding={() =>
-              setShowAddApiKeySubSection(!showAddApiKeySubSection)
-            }
-          />
-        )}
+        <ToggleAddButton
+          topicUpperCase="API KEY"
+          isAdding={showAddApiKeySubSection}
+          toggleAdding={() =>
+            setShowAddApiKeySubSection(!showAddApiKeySubSection)
+          }
+        />
       </Flex>
       <AddApiKeysSubSection
         app={app}

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.test.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { App } from "../../../Apis/api-types";
+import { AppDetailsPageContent } from "./AppDetailsPageContent";
+
+// The sections below the banner fetch subscriptions, teams, keys and
+// credentials; the breadcrumb is what these tests are about.
+vi.mock("../../../Apis/gg_hooks", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useListSubscriptionsForApp: () => ({ isLoading: false, data: [] }),
+  useListTeams: () => ({ isLoading: false, data: [] }),
+  useListApiKeysForApp: () => ({ isLoading: false, data: [] }),
+  useGetOAuthCredentialForApp: () => ({ isLoading: false, data: undefined }),
+  useListApiProducts: () => ({ isLoading: false, data: [] }),
+}));
+
+const auth = vi.hoisted(() => ({ isAdmin: false }));
+vi.mock("../../../Context/AuthContext", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useIsAdmin: () => auth.isAdmin,
+}));
+
+const app: App = {
+  id: "app-123",
+  name: "Test App",
+  description: "An app",
+  teamId: "team-456",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  deletedAt: "",
+};
+
+/** The breadcrumb link labelled "Apps", if rendered. */
+function appsCrumb() {
+  return screen
+    .queryAllByRole("link")
+    .find((el) => el.textContent?.trim() === "Apps");
+}
+
+function renderDetails() {
+  return render(
+    <MemoryRouter initialEntries={["/apps/app-123"]}>
+      <AppDetailsPageContent app={app} />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+// App details are served at /apps/:appId for admins and non-admins alike, so
+// the crumb follows the caller's mode rather than the URL.
+describe("AppDetailsPageContent breadcrumb", () => {
+  it("sends admins back to the admin apps list", () => {
+    auth.isAdmin = true;
+    renderDetails();
+
+    expect(appsCrumb()?.getAttribute("href")).toBe("/admin/apps");
+  });
+
+  it("sends non-admins back to the self-service apps list", () => {
+    auth.isAdmin = false;
+    renderDetails();
+
+    expect(appsCrumb()?.getAttribute("href")).toBe("/apps");
+  });
+});

--- a/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Apps/Details/AppDetailsPageContent.tsx
@@ -8,6 +8,7 @@ import {
   useListTeams,
 } from "../../../Apis/gg_hooks";
 import { Icon } from "../../../Assets/Icons";
+import { useIsAdmin } from "../../../Context/AuthContext";
 import { UtilityStyles } from "../../../Styles/shared/Utility.style";
 import {
   AppAuthMethod,
@@ -25,6 +26,7 @@ import AppMetadataSection from "./MetadataSection/AppMetadataSection";
 
 export const AppDetailsPageContent = ({ app }: { app: App }) => {
   di(useListSubscriptionsForApp, useListTeams);
+  const isAdmin = useIsAdmin();
   const { isLoading: isLoadingSubscriptions, data: subscriptions } =
     useListSubscriptionsForApp(app.id);
 
@@ -75,7 +77,9 @@ export const AppDetailsPageContent = ({ app }: { app: App }) => {
         }
         breadcrumbItems={[
           { label: "Home", link: "/" },
-          { label: "Apps", link: "/apps" },
+          // See TeamDetailsPageContent: the crumb follows the caller's mode,
+          // not the current URL.
+          { label: "Apps", link: isAdmin ? "/admin/apps" : "/apps" },
           { label: app.name },
         ]}
       />

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.test.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppWithTeam } from "../AppsList";
+import { AppSummaryGridCard } from "./AppSummaryGridCard";
+
+const auth = vi.hoisted(() => ({ isAdmin: true }));
+vi.mock("../../../../Context/AuthContext", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useIsAdmin: () => auth.isAdmin,
+}));
+
+const app: AppWithTeam = {
+  id: "app-123",
+  name: "Test App",
+  description: "An app",
+  teamId: "team-456",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  deletedAt: "",
+  team: {
+    id: "team-456",
+    name: "Test Team",
+    description: "A team",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+};
+
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <AppSummaryGridCard app={app} />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AppSummaryGridCard", () => {
+  // Without this link an admin can see every app but open none of them, which
+  // also puts app deletion and credential management out of reach.
+  it("links admins to the app details page", () => {
+    auth.isAdmin = true;
+    renderCard();
+
+    const details = screen.queryByText("DETAILS");
+    expect(details).not.toBeNull();
+    expect(details?.getAttribute("href")).toBe("/apps/app-123");
+  });
+
+  it("links non-admins to the app details page", () => {
+    auth.isAdmin = false;
+    renderCard();
+
+    expect(screen.queryByText("DETAILS")?.getAttribute("href")).toBe(
+      "/apps/app-123",
+    );
+  });
+});

--- a/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
+++ b/projects/ui/src/Components/Apps/PageContent/AppSummaryCards/AppSummaryGridCard.tsx
@@ -2,7 +2,6 @@ import { Box, Flex, Tooltip } from "@mantine/core";
 import { useState } from "react";
 import { NavLink } from "react-router";
 import { Icon } from "../../../../Assets/Icons";
-import { useIsAdmin } from "../../../../Context/AuthContext";
 import { CardStyles } from "../../../../Styles/shared/Card.style";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { UtilityStyles } from "../../../../Styles/shared/Utility.style";
@@ -18,7 +17,6 @@ import { AppWithTeam } from "../AppsList";
  * MAIN COMPONENT
  **/
 export function AppSummaryGridCard({ app }: { app: AppWithTeam }) {
-  const isAdmin = useIsAdmin();
   const [isWide, setIsWide] = useState(false);
 
   return (
@@ -50,13 +48,11 @@ export function AppSummaryGridCard({ app }: { app: AppWithTeam }) {
           </Flex>
         </Box>
       </div>
-      {!isAdmin && (
-        <SubscriptionInfoCardStyles.Footer>
-          <UtilityStyles.NavLinkContainer>
-            <NavLink to={getAppDetailsLink(app)}>DETAILS</NavLink>
-          </UtilityStyles.NavLinkContainer>
-        </SubscriptionInfoCardStyles.Footer>
-      )}
+      <SubscriptionInfoCardStyles.Footer>
+        <UtilityStyles.NavLinkContainer>
+          <NavLink to={getAppDetailsLink(app)}>DETAILS</NavLink>
+        </UtilityStyles.NavLinkContainer>
+      </SubscriptionInfoCardStyles.Footer>
     </GridCardStyles.GridCard>
   );
 }

--- a/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardLink.tsx
+++ b/projects/ui/src/Components/Common/SubscriptionsList/SubscriptionInfoCard/SubscriptionInfoCardLink.tsx
@@ -1,6 +1,5 @@
 import { Box, Tooltip } from "@mantine/core";
 import { NavLink, useLocation } from "react-router";
-import { useIsAdmin } from "../../../../Context/AuthContext";
 import { CardStyles } from "../../../../Styles/shared/Card.style";
 import { UtilityStyles } from "../../../../Styles/shared/Utility.style";
 
@@ -15,14 +14,13 @@ export const SubscriptionInfoCardLink = <T extends { name: string }>({
   ItemIcon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   item: undefined | null | T;
 }) => {
-  const isAdmin = useIsAdmin();
   const location = useLocation();
   const onLinkedPage = location.pathname === link;
 
   return (
     <Tooltip label={itemTypeCapitalized} position="right">
       <Box w="fit-content" sx={{ userSelect: "none" }}>
-        {!isAdmin && !!item && !onLinkedPage ? (
+        {!!item && !onLinkedPage ? (
           <UtilityStyles.LinkContainer>
             <NavLink to={link}>
               <Box pt={"3px"} pos="absolute">

--- a/projects/ui/src/Components/Home/HomePage.tsx
+++ b/projects/ui/src/Components/Home/HomePage.tsx
@@ -1,6 +1,5 @@
 import { Box } from "@mantine/core";
 import { NavLink } from "react-router";
-import { useIsAdmin } from "../../Context/AuthContext";
 import { companyName, homeImageURL } from "../../user_variables.tmplr";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
@@ -17,7 +16,6 @@ import CardImage2 from "../../Assets/card-option-2@2x.webp";
 import CardImage3 from "../../Assets/card-option-3@2x.webp";
 
 export function HomePage() {
-  const isAdmin = useIsAdmin();
   const { onApisPageClick } = useOnApisPageClick();
 
   return (
@@ -28,16 +26,14 @@ export function HomePage() {
           title={<BannerHeadingTitle text={"Developers Welcome!"} />}
           description={`Welcome to the ${companyName} Developer Portal. Connect, partner, and build with us to create the next generation of digital experiences.`}
           additionalContent={
-            !isAdmin && (
-              <NavLink to="/apis" onClick={onApisPageClick}>
-                <Button
-                  tabIndex={0}
-                  style={{ width: "150px", marginTop: "10px" }}
-                >
-                  VIEW APIS
-                </Button>
-              </NavLink>
-            )
+            <NavLink to="/apis" onClick={onApisPageClick}>
+              <Button
+                tabIndex={0}
+                style={{ width: "150px", marginTop: "10px" }}
+              >
+                VIEW APIS
+              </Button>
+            </NavLink>
           }
           tall={true}
         />

--- a/projects/ui/src/Components/Structure/Header.style.tsx
+++ b/projects/ui/src/Components/Structure/Header.style.tsx
@@ -10,6 +10,34 @@ export namespace HeaderStyles {
     padding: 5px 0px;
   `;
 
+  /**
+   * Marks the session as an admin one. The admin and non-admin views render
+   * the same pages with the same navigation labels, and the admin view lists
+   * every team and app in the portal rather than the caller's own, so the
+   * distinction has to be visible on every page.
+   *
+   * Deliberately uses the theme's existing colours: the portal is rebranded
+   * per deployment (logo, banner, company name), so a fixed accent colour
+   * would clash with some customers' palettes.
+   */
+  export const StyledAdminBadge = styled.div(
+    ({ theme }) => css`
+      margin-left: 4px;
+      padding: 3px 9px;
+      border: 1px solid ${theme.splashBlueDark10};
+      border-radius: 10px;
+
+      background-color: ${theme.splashBlue};
+      color: ${theme.defaultText};
+
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    `
+  );
+
   export const StyledTopNavHeader = styled.header(
     ({ theme }) => css`
       grid-area: header;

--- a/projects/ui/src/Components/Structure/Header.test.tsx
+++ b/projects/ui/src/Components/Structure/Header.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { ContextType } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppContext } from "../../Context/AppContext";
+import Header from "./Header";
+
+// `useIsAdmin` / `useIsLoggedIn` read from AuthContext, which needs tokens and
+// a /me request to resolve. These tests are about which nav entries the header
+// renders for a given identity, so the identity is stubbed directly.
+const auth = vi.hoisted(() => ({ isAdmin: false, isLoggedIn: true }));
+vi.mock("../../Context/AuthContext", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useIsAdmin: () => auth.isAdmin,
+  useIsLoggedIn: () => auth.isLoggedIn,
+}));
+
+/**
+ * AppContext's default value is `{}`, so `portalServerType` would be
+ * undefined and the header would render neither the gloo-gateway nor the
+ * gloo-mesh-gateway branch. Tests have to supply it.
+ */
+function renderHeader(path: string) {
+  return render(
+    <AppContext.Provider
+      value={
+        {
+          pageContentIsWide: false,
+          portalServerType: "gloo-gateway",
+        } as ContextType<typeof AppContext>
+      }
+    >
+      <MemoryRouter initialEntries={[path]}>
+        <Header />
+      </MemoryRouter>
+    </AppContext.Provider>,
+  );
+}
+
+/** The nav link with this exact text, or undefined if it isn't rendered. */
+function navLink(text: string) {
+  return screen
+    .queryAllByRole("link")
+    .find((el) => el.textContent?.trim() === text);
+}
+
+beforeEach(() => {
+  auth.isAdmin = false;
+  auth.isLoggedIn = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Header nav for admin users", () => {
+  beforeEach(() => {
+    auth.isAdmin = true;
+  });
+
+  it("offers the APIs catalog alongside the admin entries", () => {
+    renderHeader("/admin/apps");
+
+    expect(navLink("APIs")).toBeDefined();
+    expect(navLink("Teams")).toBeDefined();
+    expect(navLink("Apps")).toBeDefined();
+    expect(navLink("Subscriptions")).toBeDefined();
+  });
+
+  it("points Teams and Apps at the admin routes", () => {
+    renderHeader("/admin/apps");
+
+    expect(navLink("Teams")?.getAttribute("href")).toBe("/admin/teams");
+    expect(navLink("Apps")?.getAttribute("href")).toBe("/admin/apps");
+  });
+
+  // App and team details live at /apps/:id and /teams/:id for admins as well,
+  // so the tab has to stay highlighted outside the /admin/* path.
+  it("keeps Apps active on an app details page", () => {
+    renderHeader("/apps/app-123");
+
+    expect(navLink("Apps")?.className).toContain("active");
+  });
+
+  it("keeps Teams active on a team details page", () => {
+    renderHeader("/teams/team-123");
+
+    expect(navLink("Teams")?.className).toContain("active");
+  });
+
+  it("still marks Apps active on the admin apps list", () => {
+    renderHeader("/admin/apps");
+
+    expect(navLink("Apps")?.className).toContain("active");
+  });
+});
+
+describe("Header nav for non-admin users", () => {
+  it("offers the self-service entries and no admin entries", () => {
+    auth.isAdmin = false;
+    renderHeader("/apis");
+
+    expect(navLink("APIs")).toBeDefined();
+    expect(navLink("Teams")?.getAttribute("href")).toBe("/teams");
+    expect(navLink("Apps")?.getAttribute("href")).toBe("/apps");
+    expect(navLink("Subscriptions")).toBeUndefined();
+  });
+});
+
+describe("Header nav when logged out", () => {
+  it("offers only the APIs catalog", () => {
+    auth.isLoggedIn = false;
+    renderHeader("/apis");
+
+    expect(navLink("APIs")).toBeDefined();
+    expect(navLink("Teams")).toBeUndefined();
+    expect(navLink("Apps")).toBeUndefined();
+  });
+});

--- a/projects/ui/src/Components/Structure/Header.test.tsx
+++ b/projects/ui/src/Components/Structure/Header.test.tsx
@@ -89,6 +89,15 @@ describe("Header nav for admin users", () => {
     expect(navLink("Teams")?.className).toContain("active");
   });
 
+  // The admin and non-admin views render the same pages with the same nav
+  // labels, so this badge is the only always-visible marker of an admin
+  // session.
+  it("marks the session as an admin one", () => {
+    renderHeader("/admin/apps");
+
+    expect(screen.queryByText("Admin")).not.toBeNull();
+  });
+
   it("still marks Apps active on the admin apps list", () => {
     renderHeader("/admin/apps");
 
@@ -105,6 +114,13 @@ describe("Header nav for non-admin users", () => {
     expect(navLink("Teams")?.getAttribute("href")).toBe("/teams");
     expect(navLink("Apps")?.getAttribute("href")).toBe("/apps");
     expect(navLink("Subscriptions")).toBeUndefined();
+  });
+
+  it("does not mark the session as an admin one", () => {
+    auth.isAdmin = false;
+    renderHeader("/apis");
+
+    expect(screen.queryByText("Admin")).toBeNull();
   });
 });
 

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -102,15 +102,31 @@ const Header = () => {
                   // region [GG] Logged-in, admin
                   //
                   <>
+                    {/*
+                    // Admins get the APIs catalog too. The portal server treats
+                    // an admin as a superset of a regular user, so the catalog,
+                    // API Product details and the flows reachable from them all
+                    // work for admins.
+                    */}
+                    <ApisPageNavLink />
+                    {/*
+                    // Team and app details live at /teams/:id and /apps/:id for
+                    // admins too, so the tab has to stay active for the plain
+                    // area as well as the /admin one.
+                    */}
                     <NavLink
                       to={"/admin/teams"}
-                      className={`navLink ${inAdminTeamsArea ? "active" : ""}`}
+                      className={`navLink ${
+                        inAdminTeamsArea || inTeamsArea ? "active" : ""
+                      }`}
                     >
                       Teams
                     </NavLink>
                     <NavLink
                       to={"/admin/apps"}
-                      className={`navLink ${inAdminAppsArea ? "active" : ""}`}
+                      className={`navLink ${
+                        inAdminAppsArea || inAppsArea ? "active" : ""
+                      }`}
                     >
                       Apps
                     </NavLink>
@@ -126,14 +142,6 @@ const Header = () => {
                   // region [GG] Logged-in, non-admin
                   //
                   <>
-                    {/*
-                    // If we allow admins to access the APIs page, things get a bit
-                    // more confusing, since we will have to consider the behavior
-                    // of the API details pages and pending subscriptions tabs.
-                    // For example, a user can create an App from the API details page,
-                    // so it would be strange for the admin not to have access to
-                    // the Apps page in that case.
-                    */}
                     <ApisPageNavLink />
                     <NavLink
                       to={"/teams"}

--- a/projects/ui/src/Components/Structure/Header.tsx
+++ b/projects/ui/src/Components/Structure/Header.tsx
@@ -76,6 +76,11 @@ const Header = () => {
               <Logo />
             )}
           </Link>
+          {isLoggedIn && isAdmin && (
+            <HeaderStyles.StyledAdminBadge title="You are signed in as a portal administrator">
+              Admin
+            </HeaderStyles.StyledAdminBadge>
+          )}
         </div>
         <div className="siteNavigating">
           <NavLink to={"/"} className={"navLink"} end>

--- a/projects/ui/src/Components/Teams/Details/AppsSection/TeamAppsSection.tsx
+++ b/projects/ui/src/Components/Teams/Details/AppsSection/TeamAppsSection.tsx
@@ -4,7 +4,6 @@ import { di } from "react-magnetic-di";
 import { NavLink } from "react-router";
 import { Team } from "../../../../Apis/api-types";
 import { useListAppsForTeam } from "../../../../Apis/gg_hooks";
-import { useIsAdmin } from "../../../../Context/AuthContext";
 import { DetailsPageStyles } from "../../../../Styles/shared/DetailsPageStyles";
 import { GridCardStyles } from "../../../../Styles/shared/GridCard.style";
 import { UtilityStyles } from "../../../../Styles/shared/Utility.style";
@@ -22,7 +21,6 @@ import AddTeamAppSubSection from "./AddTeamAppSubSection";
 
 const TeamAppsSection = ({ team }: { team: Team }) => {
   di(useListAppsForTeam);
-  const isAdmin = useIsAdmin();
   const { isLoading, data: apps } = useListAppsForTeam(team);
   const [showAddTeamAppSubSection, setShowAddTeamAppSubSection] =
     useState(false);
@@ -44,17 +42,15 @@ const TeamAppsSection = ({ team }: { team: Team }) => {
             <td>
               {app.deletedAt && formatDateToMMDDYYYY(new Date(app.deletedAt))}
             </td>
-            {!isAdmin && (
-              <td>
-                <UtilityStyles.CenteredCellContent>
-                  <Box mr={"-5%"}>
-                    <UtilityStyles.NavLinkContainer>
-                      <NavLink to={getAppDetailsLink(app)}>DETAILS</NavLink>
-                    </UtilityStyles.NavLinkContainer>
-                  </Box>
-                </UtilityStyles.CenteredCellContent>
-              </td>
-            )}
+            <td>
+              <UtilityStyles.CenteredCellContent>
+                <Box mr={"-5%"}>
+                  <UtilityStyles.NavLinkContainer>
+                    <NavLink to={getAppDetailsLink(app)}>DETAILS</NavLink>
+                  </UtilityStyles.NavLinkContainer>
+                </Box>
+              </UtilityStyles.CenteredCellContent>
+            </td>
           </tr>
         ) ?? []
     );
@@ -67,23 +63,19 @@ const TeamAppsSection = ({ team }: { team: Team }) => {
     <DetailsPageStyles.Section>
       <Flex justify={"space-between"}>
         <DetailsPageStyles.Title>Apps</DetailsPageStyles.Title>
-        {!isAdmin && (
-          <ToggleAddButton
-            topicUpperCase="APP"
-            isAdding={showAddTeamAppSubSection}
-            toggleAdding={() =>
-              setShowAddTeamAppSubSection(!showAddTeamAppSubSection)
-            }
-          />
-        )}
-      </Flex>
-      {!isAdmin && (
-        <AddTeamAppSubSection
-          team={team}
-          open={showAddTeamAppSubSection}
-          onClose={() => setShowAddTeamAppSubSection(false)}
+        <ToggleAddButton
+          topicUpperCase="APP"
+          isAdding={showAddTeamAppSubSection}
+          toggleAdding={() =>
+            setShowAddTeamAppSubSection(!showAddTeamAppSubSection)
+          }
         />
-      )}
+      </Flex>
+      <AddTeamAppSubSection
+        team={team}
+        open={showAddTeamAppSubSection}
+        onClose={() => setShowAddTeamAppSubSection(false)}
+      />
       {!apps?.length ? (
         <Box mb={"-30px"} mt={"30px"}>
           <EmptyData title="No Apps were found." />
@@ -99,13 +91,11 @@ const TeamAppsSection = ({ team }: { team: Team }) => {
                     <th>Created</th>
                     <th>Updated</th>
                     <th>Deleted</th>
-                    {!isAdmin && (
-                      <th>
-                        <UtilityStyles.CenteredCellContent>
-                          Details
-                        </UtilityStyles.CenteredCellContent>
-                      </th>
-                    )}
+                    <th>
+                      <UtilityStyles.CenteredCellContent>
+                        Details
+                      </UtilityStyles.CenteredCellContent>
+                    </th>
                   </tr>
                 </thead>
                 <tbody>{rows}</tbody>

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.test.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Team } from "../../../Apis/api-types";
+import TeamDetailsPageContent from "./TeamDetailsPageContent";
+
+// The sections below the banner fetch the team's apps and members; the
+// breadcrumb is what these tests are about.
+vi.mock("../../../Apis/gg_hooks", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useListAppsForTeam: () => ({ isLoading: false, data: [] }),
+  useListUsersForTeam: () => ({ isLoading: false, data: [] }),
+  useListTeamMembers: () => ({ isLoading: false, data: [] }),
+}));
+
+const auth = vi.hoisted(() => ({ isAdmin: false }));
+vi.mock("../../../Context/AuthContext", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useIsAdmin: () => auth.isAdmin,
+}));
+
+const team: Team = {
+  id: "team-456",
+  name: "Test Team",
+  description: "A team",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+/** The breadcrumb link labelled "Teams", if rendered. */
+function teamsCrumb() {
+  return screen
+    .queryAllByRole("link")
+    .find((el) => el.textContent?.trim() === "Teams");
+}
+
+function renderDetails() {
+  return render(
+    <MemoryRouter initialEntries={["/teams/team-456"]}>
+      <TeamDetailsPageContent team={team} />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+// Team details are served at /teams/:teamId for admins and non-admins alike.
+// The crumb has to lead back to the list the caller's mode populates, or an
+// admin lands on a page whose copy contradicts what the backend returned.
+describe("TeamDetailsPageContent breadcrumb", () => {
+  it("sends admins back to the admin teams list", () => {
+    auth.isAdmin = true;
+    renderDetails();
+
+    expect(teamsCrumb()?.getAttribute("href")).toBe("/admin/teams");
+  });
+
+  it("sends non-admins back to the self-service teams list", () => {
+    auth.isAdmin = false;
+    renderDetails();
+
+    expect(teamsCrumb()?.getAttribute("href")).toBe("/teams");
+  });
+});

--- a/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
+++ b/projects/ui/src/Components/Teams/Details/TeamDetailsPageContent.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex } from "@mantine/core";
 import { Team } from "../../../Apis/api-types";
 import { Icon } from "../../../Assets/Icons";
+import { useIsAdmin } from "../../../Context/AuthContext";
 import { BannerHeading } from "../../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../../Common/Banner/BannerHeadingTitle";
 import { PageContainer } from "../../Common/PageContainer";
@@ -9,6 +10,8 @@ import EditTeamButtonWithModal from "./EditTeamButtonWithModal";
 import TeamUsersSection from "./UsersSection/TeamUsersSection";
 
 const TeamDetailsPageContent = ({ team }: { team: Team }) => {
+  const isAdmin = useIsAdmin();
+
   return (
     <PageContainer>
       <BannerHeading
@@ -26,7 +29,10 @@ const TeamDetailsPageContent = ({ team }: { team: Team }) => {
         description={team.description}
         breadcrumbItems={[
           { label: "Home", link: "/" },
-          { label: "Teams", link: "/teams" },
+          // Team details are shared between the admin and self-service
+          // views, so the crumb has to lead back to whichever list the
+          // caller's mode actually populates.
+          { label: "Teams", link: isAdmin ? "/admin/teams" : "/teams" },
           { label: team.name },
         ]}
       />

--- a/projects/ui/src/Components/Teams/TeamsPage.test.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.test.tsx
@@ -46,4 +46,32 @@ describe("TeamsPage", () => {
 
     expect(screen.queryByText("CREATE NEW TEAM")).not.toBeNull();
   });
+
+  // The list is scoped to the caller on /teams and covers the whole
+  // portal on /admin/teams, so the wording has to distinguish them.
+  it("says the list covers the whole portal on the admin route", () => {
+    render(
+      <MemoryRouter initialEntries={["/admin/teams"]}>
+        <TeamsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse all teams in this portal."),
+    ).not.toBeNull();
+    expect(screen.queryByText("Browse the teams you belong to.")).toBeNull();
+  });
+
+  it("says the list is the caller's own on the self-service route", () => {
+    render(
+      <MemoryRouter initialEntries={["/teams"]}>
+        <TeamsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse the teams you belong to."),
+    ).not.toBeNull();
+    expect(screen.queryByText("Browse all teams in this portal.")).toBeNull();
+  });
 });

--- a/projects/ui/src/Components/Teams/TeamsPage.test.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TeamsPage } from "./TeamsPage";
+
+// The page and its create-team modal read the team list and the create
+// mutation on render. Neither is what these tests are about.
+vi.mock("../../Apis/gg_hooks", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useListTeams: () => ({ isLoading: false, data: [] }),
+  useCreateTeamMutation: () => ({ trigger: vi.fn() }),
+}));
+
+const auth = vi.hoisted(() => ({ isAdmin: true }));
+vi.mock("../../Context/AuthContext", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useIsAdmin: () => auth.isAdmin,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+// TeamsPage is also served as /admin/teams (AdminTeamsPage re-exports it), so
+// this covers the admin teams page as well as the self-service one.
+describe("TeamsPage", () => {
+  it("offers team creation to admins", () => {
+    auth.isAdmin = true;
+    render(
+      <MemoryRouter>
+        <TeamsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("CREATE NEW TEAM")).not.toBeNull();
+  });
+
+  it("offers team creation to non-admins", () => {
+    auth.isAdmin = false;
+    render(
+      <MemoryRouter>
+        <TeamsPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("CREATE NEW TEAM")).not.toBeNull();
+  });
+});

--- a/projects/ui/src/Components/Teams/TeamsPage.test.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.test.tsx
@@ -47,11 +47,25 @@ describe("TeamsPage", () => {
     expect(screen.queryByText("CREATE NEW TEAM")).not.toBeNull();
   });
 
-  // The list is scoped to the caller on /teams and covers the whole
-  // portal on /admin/teams, so the wording has to distinguish them.
-  it("says the list covers the whole portal on the admin route", () => {
+  // The portal server scopes the list to the caller's mode, not the URL, so
+  // an admin on /teams still sees every team. The copy must say so.
+  it("says the list covers the whole portal for admins", () => {
+    auth.isAdmin = true;
     render(
       <MemoryRouter initialEntries={["/admin/teams"]}>
+        <TeamsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse all teams in this portal."),
+    ).not.toBeNull();
+  });
+
+  it("says the list covers the whole portal for admins on /teams too", () => {
+    auth.isAdmin = true;
+    render(
+      <MemoryRouter initialEntries={["/teams"]}>
         <TeamsPage />
       </MemoryRouter>,
     );
@@ -62,7 +76,8 @@ describe("TeamsPage", () => {
     expect(screen.queryByText("Browse the teams you belong to.")).toBeNull();
   });
 
-  it("says the list is the caller's own on the self-service route", () => {
+  it("says the list is membership-scoped for non-admins", () => {
+    auth.isAdmin = false;
     render(
       <MemoryRouter initialEntries={["/teams"]}>
         <TeamsPage />
@@ -73,5 +88,19 @@ describe("TeamsPage", () => {
       screen.queryByText("Browse the teams you belong to."),
     ).not.toBeNull();
     expect(screen.queryByText("Browse all teams in this portal.")).toBeNull();
+  });
+
+  // The route alone must not move the copy.
+  it("keeps the membership-scoped copy for a non-admin on the admin route", () => {
+    auth.isAdmin = false;
+    render(
+      <MemoryRouter initialEntries={["/admin/teams"]}>
+        <TeamsPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText("Browse the teams you belong to."),
+    ).not.toBeNull();
   });
 });

--- a/projects/ui/src/Components/Teams/TeamsPage.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.tsx
@@ -4,19 +4,17 @@ import { Icon } from "../../Assets/Icons";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
+import { useIsAdmin } from "../../Context/AuthContext";
 import { PageContainer } from "../Common/PageContainer";
-import { useInArea } from "../../Utility/utility";
 import CreateNewTeamModal from "./Modals/CreateNewTeamModal";
 import { TeamsList } from "./TeamsList/TeamsList";
 
 export function TeamsPage() {
   const [modalOpen, setModalOpen] = useState(false);
-  // This page is served at both /teams and /admin/teams (AdminTeamsPage
-  // re-exports it), and the portal server scopes the team list to the caller
-  // on one and returns every team on the other. Derive the wording from the
-  // route rather than from `useIsAdmin`, so it describes what is on screen
-  // rather than who is looking at it.
-  const inAdminArea = useInArea(["/admin/teams"]);
+  // The portal server scopes the team list to the caller's effective mode,
+  // not to the URL: admins get every team on /teams as well as on
+  // /admin/teams. So the wording follows the mode, not the route.
+  const isAdmin = useIsAdmin();
 
   return (
     <PageContainer>
@@ -24,7 +22,7 @@ export function TeamsPage() {
         title={<BannerHeadingTitle text={"Teams"} logo={<Icon.TeamsIcon />} />}
         description={
           <>
-            {inAdminArea
+            {isAdmin
               ? "Browse all teams in this portal."
               : "Browse the teams you belong to."}
             <Box pt={"20px"}>

--- a/projects/ui/src/Components/Teams/TeamsPage.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.tsx
@@ -1,7 +1,6 @@
 import { Box } from "@mantine/core";
 import { useState } from "react";
 import { Icon } from "../../Assets/Icons";
-import { useIsAdmin } from "../../Context/AuthContext";
 import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
@@ -10,7 +9,6 @@ import CreateNewTeamModal from "./Modals/CreateNewTeamModal";
 import { TeamsList } from "./TeamsList/TeamsList";
 
 export function TeamsPage() {
-  const isAdmin = useIsAdmin();
   const [modalOpen, setModalOpen] = useState(false);
 
   return (
@@ -20,13 +18,11 @@ export function TeamsPage() {
         description={
           <>
             Browse the list of teams.
-            {!isAdmin && (
-              <Box pt={"20px"}>
-                <Button onClick={() => setModalOpen(true)}>
-                  CREATE NEW TEAM
-                </Button>
-              </Box>
-            )}
+            <Box pt={"20px"}>
+              <Button onClick={() => setModalOpen(true)}>
+                CREATE NEW TEAM
+              </Button>
+            </Box>
           </>
         }
         breadcrumbItems={[{ label: "Home", link: "/" }, { label: "Teams" }]}
@@ -34,12 +30,10 @@ export function TeamsPage() {
       <Box px={"30px"} pb={"10px"}>
         <TeamsList />
       </Box>
-      {!isAdmin && (
-        <CreateNewTeamModal
-          open={modalOpen}
-          onClose={() => setModalOpen(false)}
-        />
-      )}
+      <CreateNewTeamModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
     </PageContainer>
   );
 }

--- a/projects/ui/src/Components/Teams/TeamsPage.tsx
+++ b/projects/ui/src/Components/Teams/TeamsPage.tsx
@@ -5,11 +5,18 @@ import { BannerHeading } from "../Common/Banner/BannerHeading";
 import { BannerHeadingTitle } from "../Common/Banner/BannerHeadingTitle";
 import { Button } from "../Common/Button";
 import { PageContainer } from "../Common/PageContainer";
+import { useInArea } from "../../Utility/utility";
 import CreateNewTeamModal from "./Modals/CreateNewTeamModal";
 import { TeamsList } from "./TeamsList/TeamsList";
 
 export function TeamsPage() {
   const [modalOpen, setModalOpen] = useState(false);
+  // This page is served at both /teams and /admin/teams (AdminTeamsPage
+  // re-exports it), and the portal server scopes the team list to the caller
+  // on one and returns every team on the other. Derive the wording from the
+  // route rather than from `useIsAdmin`, so it describes what is on screen
+  // rather than who is looking at it.
+  const inAdminArea = useInArea(["/admin/teams"]);
 
   return (
     <PageContainer>
@@ -17,7 +24,9 @@ export function TeamsPage() {
         title={<BannerHeadingTitle text={"Teams"} logo={<Icon.TeamsIcon />} />}
         description={
           <>
-            Browse the list of teams.
+            {inAdminArea
+              ? "Browse all teams in this portal."
+              : "Browse the teams you belong to."}
             <Box pt={"20px"}>
               <Button onClick={() => setModalOpen(true)}>
                 CREATE NEW TEAM

--- a/projects/ui/src/setupTests.ts
+++ b/projects/ui/src/setupTests.ts
@@ -30,3 +30,26 @@ Object.defineProperty(window, "localStorage", {
     clear: () => storage.clear(),
   } satisfies Storage,
 });
+
+// jsdom does not implement `matchMedia`, and Mantine components that animate
+// (Transition, and anything built on it such as the header's auth dropdown)
+// call it during render. Without this, those subtrees throw and any
+// surrounding ErrorBoundary renders its fallback instead of the component.
+// Nothing under test depends on media queries actually matching, so this
+// reports "no match" and records no listeners.
+const noop = () => undefined;
+Object.defineProperty(window, "matchMedia", {
+  configurable: true,
+  writable: true,
+  value: (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: () => false,
+    // Deprecated, but Mantine 6 still calls these.
+    addListener: noop,
+    removeListener: noop,
+  }),
+});


### PR DESCRIPTION
The portal server already treats an admin as a superset of a regular user: visibility policy is skipped for admins, team and app operations ignore membership, and the list endpoints return everything. Only app metadata, subscription metadata and subscription approve/reject are admin-only. The reference UI withheld all of it — no catalog, no way to open an app, no team or app creation, while team deletion stayed available. This removes those UI guards. No server changes.

## Changes

- **Catalog** — APIs entry in the admin nav plus the home page card: catalog, API Product details, spec views, try-it-out.
- **Reachability** — app DETAILS links on the Apps page, team app lists and subscription cards. Also restores app deletion and credential management, which live on that page.
- **Creation** — create app, create team, add team app, add API key.
- **Nav state** — Teams and Apps tabs stay active on `/teams/:id` and `/apps/:id`.
- **Admin marker** — Admin badge in the header, and Teams/Apps state their scope ("Browse all teams in this portal." vs "Browse the teams you belong to."). Both routes render the same component and admins get portal-wide data on either, so without this an admin reads a portal-wide list as their own.
- **Mode over URL** — detail breadcrumbs and scope copy follow `isAdmin`, not the route. Previously an admin opening a team from `/admin/teams` and clicking the crumb landed on `/teams` and was told those were their own teams. A future "view as user" downgrade then needs no change here.

## Testing

`yarn test` 53 passing (was 26); `yarn build`, `yarn lint`, `git diff --check` clean.

Covers admin nav and route targets, tab active state, create controls, app-details links, the badge, both breadcrumbs in both modes, and scope copy following mode — including an admin on `/teams` getting the admin copy and a non-admin on `/admin/teams` not, so the route alone cannot move it. Non-admin and logged-out navs asserted unchanged. Each new test is mutation-checked: reinstating a guard, hard-coding a breadcrumb, or route-sourcing the copy fails it.

`setupTests.ts` gains a `window.matchMedia` stub — jsdom lacks it and Mantine's `Transition` calls it during render.

Verified manually as an admin against a live portal: catalog, details with Redoc/Swagger, subscribing from a details page including inline app creation, team creation, app details, API key creation.

**Gap:** no e2e coverage of the mutations. `mock-portal-api` has four read-only routes and no `/v1/me`, teams, apps or subscriptions, so the Playwright suite cannot reach anything behind login. Tracked separately.

## For reviewers

- **Admins can approve their own subscriptions.** Inherent to the superset model, not new here: approve is admin-only, and an admin could always create a subscription through an app they can reach and then approve it via the API. The admin group is the approver.
- **Team creator membership.** The server auto-adds a creator as a member, and for an admin that membership outlives their admin role. Exposing Create Team makes this routine, not newly possible — team creation was already open to any authenticated caller. The server-side fix is tracked separately and does not block this.